### PR TITLE
[PR] Fix unix time calc on ECS

### DIFF
--- a/SEC/readSEC.js
+++ b/SEC/readSEC.js
@@ -92,9 +92,6 @@ const axios = require("axios");
 
   // non-unix time calc
   const dateObj = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
-  
-  console.log(dateObj)
-  
   const localeTime = dateObj
     .toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
     .match(/\d+/g);
@@ -104,31 +101,32 @@ const axios = require("axios");
 
   // Automatically detects the timezone difference of US Pacific vs GMT-0 (7 or 8 depending on daylight savings)
   // https://stackoverflow.com/questions/20712419/get-utc-offset-from-timezone-in-javascript
-const getOffset = (timeZone) => {
-  const timeZoneName = Intl.DateTimeFormat("ia", {
-    timeZoneName: "shortOffset",
-    timeZone,
-  })
-    .formatToParts()
-    .find((i) => i.type === "timeZoneName").value;
-  const offset = timeZoneName.slice(3);
-  if (!offset) return 0;
+  const getOffset = (timeZone) => {
+    const timeZoneName = Intl.DateTimeFormat("ia", {
+      timeZoneName: "shortOffset",
+      timeZone,
+    })
+      .formatToParts()
+      .find((i) => i.type === "timeZoneName").value;
+    const offset = timeZoneName.slice(3);
+    if (!offset) return 0;
 
-  const matchData = offset.match(/([+-])(\d+)(?::(\d+))?/);
-  if (!matchData) throw `cannot parse timezone name: ${timeZoneName}`;
+    const matchData = offset.match(/([+-])(\d+)(?::(\d+))?/);
+    if (!matchData) throw `cannot parse timezone name: ${timeZoneName}`;
 
-  const [, sign, hour, minute] = matchData;
-  let result = parseInt(hour) * 60;
-  if (sign === "+") result *= -1;
-  if (minute) result += parseInt(minute);
+    const [, sign, hour, minute] = matchData;
+    let result = parseInt(hour) * 60;
+    if (sign === "+") result *= -1;
+    if (minute) result += parseInt(minute);
 
-  return result;
-};
+    return result;
+  };
 
-console.log(getOffset("US/Pacific"));
-  const dateObjUnix = new Date(new Date().getTime() - (24 * 60 * 60 * 1000 + getOffset("US/Pacific") * 60 * 1000));
-  console.log(dateObjUnix)
-
+  console.log(getOffset("US/Pacific"));
+  const dateObjUnix = new Date(
+    new Date().getTime() -
+      (24 * 60 * 60 * 1000 + getOffset("US/Pacific") * 60 * 1000),
+  );
 
   // unix time calc
   dateObjUnix.setUTCHours(23, 59, 59, 0);
@@ -190,7 +188,7 @@ console.log(getOffset("US/Pacific"));
 
     // Comment out the axios POST request as specified below for local development (unless making changes to upload stuff).
     // Uncomment this section before pushing to production.
-     /* block comment starts here
+    // /* block comment starts here
     await axios({
       method: "post",
       url: `${process.env.DASHBOARD_API}/upload`,
@@ -210,7 +208,7 @@ console.log(getOffset("US/Pacific"));
       .catch((err) => {
         console.log(err);
       });
-     */ //block comment ends here
+    // */ //block comment ends here
   }
 
   // Close browser.

--- a/SEC/readSEC.js
+++ b/SEC/readSEC.js
@@ -92,6 +92,9 @@ const axios = require("axios");
 
   // non-unix time calc
   const dateObj = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
+  
+  console.log(dateObj)
+  
   const localeTime = dateObj
     .toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
     .match(/\d+/g);
@@ -99,12 +102,37 @@ const axios = require("axios");
     localeTime[2] + "-" + localeTime[0] + "-" + Number(localeTime[1]);
   const END_TIME = `${DATE}T23:59:59`;
 
-  // set to 2am to fix rounding error due to daylight savings
-  dateObj.setHours(2, 0, 0);
+  // Automatically detects the timezone difference of US Pacific vs GMT-0 (7 or 8 depending on daylight savings)
+  // https://stackoverflow.com/questions/20712419/get-utc-offset-from-timezone-in-javascript
+const getOffset = (timeZone) => {
+  const timeZoneName = Intl.DateTimeFormat("ia", {
+    timeZoneName: "shortOffset",
+    timeZone,
+  })
+    .formatToParts()
+    .find((i) => i.type === "timeZoneName").value;
+  const offset = timeZoneName.slice(3);
+  if (!offset) return 0;
+
+  const matchData = offset.match(/([+-])(\d+)(?::(\d+))?/);
+  if (!matchData) throw `cannot parse timezone name: ${timeZoneName}`;
+
+  const [, sign, hour, minute] = matchData;
+  let result = parseInt(hour) * 60;
+  if (sign === "+") result *= -1;
+  if (minute) result += parseInt(minute);
+
+  return result;
+};
+
+console.log(getOffset("US/Pacific"));
+  const dateObjUnix = new Date(new Date().getTime() - (24 * 60 * 60 * 1000 + getOffset("US/Pacific") * 60 * 1000));
+  console.log(dateObjUnix)
+
 
   // unix time calc
-  dateObj.setUTCHours(23, 59, 59, 0);
-  const END_TIME_SECONDS = Math.floor(dateObj.valueOf() / 1000).toString();
+  dateObjUnix.setUTCHours(23, 59, 59, 0);
+  const END_TIME_SECONDS = Math.floor(dateObjUnix.valueOf() / 1000).toString();
 
   console.log(END_TIME_SECONDS);
 
@@ -162,7 +190,7 @@ const axios = require("axios");
 
     // Comment out the axios POST request as specified below for local development (unless making changes to upload stuff).
     // Uncomment this section before pushing to production.
-    // /* block comment starts here
+     /* block comment starts here
     await axios({
       method: "post",
       url: `${process.env.DASHBOARD_API}/upload`,
@@ -182,7 +210,7 @@ const axios = require("axios");
       .catch((err) => {
         console.log(err);
       });
-    // */ //block comment ends here
+     */ //block comment ends here
   }
 
   // Close browser.

--- a/SEC/readSEC.js
+++ b/SEC/readSEC.js
@@ -92,14 +92,15 @@ const axios = require("axios");
 
   // non-unix time calc
   const dateObj = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
-  // set to 2am to fix rounding error due to daylight savings
-  dateObj.setHours(2, 0, 0);
   const localeTime = dateObj
     .toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
     .match(/\d+/g);
   const DATE =
     localeTime[2] + "-" + localeTime[0] + "-" + Number(localeTime[1]);
   const END_TIME = `${DATE}T23:59:59`;
+
+  // set to 2am to fix rounding error due to daylight savings
+  dateObj.setHours(2, 0, 0);
 
   // unix time calc
   dateObj.setUTCHours(23, 59, 59, 0);

--- a/ennex-os/readEnnex.js
+++ b/ennex-os/readEnnex.js
@@ -63,9 +63,6 @@ const meterlist = require("./meterlist.json");
 
   // non-unix time calc
   const dateObj = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
-  
-  console.log(dateObj)
-
   const localeTime = dateObj
     .toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
     .match(/\d+/g);
@@ -94,30 +91,32 @@ const meterlist = require("./meterlist.json");
 
   // Automatically detects the timezone difference of US Pacific vs GMT-0 (7 or 8 depending on daylight savings)
   // https://stackoverflow.com/questions/20712419/get-utc-offset-from-timezone-in-javascript
-const getOffset = (timeZone) => {
-  const timeZoneName = Intl.DateTimeFormat("ia", {
-    timeZoneName: "shortOffset",
-    timeZone,
-  })
-    .formatToParts()
-    .find((i) => i.type === "timeZoneName").value;
-  const offset = timeZoneName.slice(3);
-  if (!offset) return 0;
+  const getOffset = (timeZone) => {
+    const timeZoneName = Intl.DateTimeFormat("ia", {
+      timeZoneName: "shortOffset",
+      timeZone,
+    })
+      .formatToParts()
+      .find((i) => i.type === "timeZoneName").value;
+    const offset = timeZoneName.slice(3);
+    if (!offset) return 0;
 
-  const matchData = offset.match(/([+-])(\d+)(?::(\d+))?/);
-  if (!matchData) throw `cannot parse timezone name: ${timeZoneName}`;
+    const matchData = offset.match(/([+-])(\d+)(?::(\d+))?/);
+    if (!matchData) throw `cannot parse timezone name: ${timeZoneName}`;
 
-  const [, sign, hour, minute] = matchData;
-  let result = parseInt(hour) * 60;
-  if (sign === "+") result *= -1;
-  if (minute) result += parseInt(minute);
+    const [, sign, hour, minute] = matchData;
+    let result = parseInt(hour) * 60;
+    if (sign === "+") result *= -1;
+    if (minute) result += parseInt(minute);
 
-  return result;
-};
+    return result;
+  };
 
-console.log(getOffset("US/Pacific"));
-  const dateObjUnix = new Date(new Date().getTime() - (24 * 60 * 60 * 1000 + getOffset("US/Pacific") * 60 * 1000));
-  console.log(dateObjUnix)
+  console.log(getOffset("US/Pacific"));
+  const dateObjUnix = new Date(
+    new Date().getTime() -
+      (24 * 60 * 60 * 1000 + getOffset("US/Pacific") * 60 * 1000),
+  );
 
   // unix time calc
   dateObjUnix.setUTCHours(23, 59, 59, 0);
@@ -326,7 +325,7 @@ console.log(getOffset("US/Pacific"));
 
     // Comment out the axios POST request as specified below for local development (unless making changes to upload stuff).
     // Uncomment this section before pushing to production.
-     /* block comment starts here
+    // /* block comment starts here
     await axios({
       method: "post",
       url: `${process.env.DASHBOARD_API}/upload`,
@@ -346,7 +345,7 @@ console.log(getOffset("US/Pacific"));
       .catch((err) => {
         console.log(err);
       });
-     */ //block comment ends here
+    // */ //block comment ends here
   }
 
   // Close browser.

--- a/ennex-os/readEnnex.js
+++ b/ennex-os/readEnnex.js
@@ -63,8 +63,7 @@ const meterlist = require("./meterlist.json");
 
   // non-unix time calc
   const dateObj = new Date(new Date().getTime() - 24 * 60 * 60 * 1000);
-  // set to 2am to fix rounding error due to daylight savings
-  dateObj.setHours(2, 0, 0);
+
   const localeTime = dateObj
     .toLocaleString("en-US", { timeZone: "America/Los_Angeles" })
     .match(/\d+/g);
@@ -72,6 +71,9 @@ const meterlist = require("./meterlist.json");
     localeTime[2] + "-" + localeTime[0] + "-" + Number(localeTime[1]);
   const END_TIME = `${DATE}T23:59:59`;
   console.log(END_TIME);
+
+  // set to 2am to fix rounding error due to daylight savings
+  dateObj.setHours(2, 0, 0);
 
   let ENNEX_MONTH = "";
   if (parseInt(localeTime[0]) < 10) {


### PR DESCRIPTION
branch: `fix-debug-human-time`

## Issue
The issue was that on ECS, the timezone is already in GMT - 0, leading to inconsistent results on local PC in Pacific Timezone (GMT - 8 with current daylight savings) vs on ECS.

![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/82061589/1564c012-f346-4dfc-8b90-6965364a20a0)
- See how the value on the right (`console.log(dateObj)`) is in a different timezone than value on left (local / Pacific timezone)

I found a solution StackOverflow to automatically get the timezone difference from GMT 0 to Pacific Timezone
- https://stackoverflow.com/questions/20712419/get-utc-offset-from-timezone-in-javascript (top answer)

- Setting the time to 2AM as with previous approach (https://github.com/OSU-Sustainability-Office/automated-jobs/pull/33) was flawed because it did not account for ECS not being in PST (or something, I thought we were in Oregon region of AWS)
  - This probably also was the cause of why the human-readable `time` variable became a day behind. Just in case, I separated out `dateObj` and `dateObjUnix` in my new PR. Since the issue previously was just with the Unix values, not the human readable `time` variable

## Still need to do before merge
- Test again sometime in morning (locally and via ECS / cloudwatch) as sanity check
  - Test `time_seconds` value against https://www.unixtimestamp.com/index.php
  - Also check the human readable date variable `time` looks correct
  - Leave upload function commented out for now. But we can fix database later, so don't worry either way
- Didn't really test ennex-os yet, but should work the same
- Uncomment upload function after testing it works on ECS / Cloudwatch
- `npm run format` in SEC / ennex-os directories
- Remove extraneous `console.log(dataObj)` and `console.log(dataObjUnix)` statements after verifying it works locally / on ECS and Cloudwatch