### PR TITLE
Null Meter Group Check

### DIFF
--- a/check-acq/check-acq.js
+++ b/check-acq/check-acq.js
@@ -50,6 +50,10 @@ axios
         let meterGroupTable = [];
         const meterGroupLength = buildings.meterGroups.length;
         for (let i = 0; i < meterGroupLength; i++) {
+          // skip buildings with null meter groups
+          if (buildings.meterGroups[i].id === "null") {
+            continue;
+          }
           const meterLength = buildings.meterGroups[i].meters.length;
           meterGroupTable.push(buildings.meterGroups[i].id);
           for (let j = 0; j < meterLength; j++) {


### PR DESCRIPTION
Null Meter Group Check
- If buildings are added before meter groups, this can cause the check-acq script to error, so I did a check to skip to next iteration of loop if null meter group id is detected