### PR TITLE
Retrieve cloudwatch logs through cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,20 @@ Through the AWS Management Console we define Scheduled Tasks which run each cont
 whatever AWS calls them).
 
 ## Currently Active Jobs
-All console commands below should be run from the directory unless stated otherwise, e.g. do `cd SEC` before `node readSEC.js`
+All console commands below should be run from the directory (names in **bold**) unless stated otherwise, e.g. do `cd SEC` before `node readSEC.js`.
+
+Similarly, any files listed should be assumed to be located within the directory instead of root (e.g. `blacklist.json` should be understood to be located in `check-acq/blacklist.json`)
 
 - **SEC** (Deployed): Retrieves some solar panel data from Student Experience Center. Email alerts integrated for failed upload.
   - `node readSEC.js`
 - **ennex-os** (Deployed): Retrieves some solar panel data from OSU Operations. Email alerts integrated for failed upload.
   - `node readEnnex.js`
-- **Check-Acq** (Deployed): Checks for Acquisuite (not solar panel) meter status. Email alerts integrated for missing or unchanging data.
+- **check-acq** (Deployed): Checks for Acquisuite (not solar panel) meter status. Email alerts integrated for missing or unchanging data.
   - `node check-acq.js --<measurement> --save-output`
-    - `--save-output` Optional argument, saves output to `check-acq/mergedFinalDataOutput.json` or `check-acq/mergedFinalDataOutput.txt` (note that this output.json file is in .gitignore, it is not tracked on remote)
+    - `--save-output` Optional argument, saves output to `mergedFinalDataOutput.json` or `mergedFinalDataOutput.txt` (note that this output.json file is in .gitignore, it is not tracked on remote)
     - `--<measurement>` Optional argument. Choose `--negative`, `--nodata`, or `--nochange`. This restricts the script to only collect info on one specified measurement of negative data, missing data (`--nodata` flag), non-changing data
       - e.g. `node check-acq.js --negative --save-output` to filter for negative data only
-      - Combining this with `--save-output` will add `Negative`, `NoData`, or `NoChange` to the output file name, e.g. `check-acq/mergedFinalDataOutputNegative.json`
+      - Combining this with `--save-output` will add `Negative`, `NoData`, or `NoChange` to the output file name, e.g. `mergedFinalDataOutputNegative.json`
       - Not providing the measurement argument will result in all measurements being collected
     - Sorted by meter ID (since summary section of output references them)
     - Meters with undefined meter group ID / meter ID / points are skipped
@@ -28,6 +30,7 @@ All console commands below should be run from the directory unless stated otherw
     - See `check.acq.js` code comments for more specific documentation of measurement collection logic, handling non-200 return code errors etc
   - `node check-acq.js --all-meters`
     - `all-meters` Optional argument. Do not include other arguments with this command. Gets all unique meters from allBuildings API call (except for meters that are in `blacklist.json`) and lists them as a flattened array of objects. Like the regular-acq script, uses `meter_id`, `building_id`, etc for more ease in searching
+    - Output saved to `allMeters.json`
     - Sorted by building ID, then meter ID, like allBuildings API call
     - Meters with undefined meter group ID / meter ID / points are skipped
     - Duplicate meters are skipped
@@ -44,6 +47,15 @@ All console commands below should be run from the directory unless stated otherw
     - No other changes made to the data (unlike with check-acq.js)
     - Or use https://jsonformatter.org/ (with fullscreen button in upper right)
 
+## Local Use Only
+- **cloudwatch-cli**
+  - `node fetchLogs.js`
+    - Retrieves most recent cloudwatch logs from a given ECS container via the AWS CLI, to save time having to deal with AWS website interface, and to make it easier to download log files to managers when needed
+    - The exact amount of logs, and which ECS container, can be configured in the variables at the top of `retrieveLogs` file
+    - Must have AWS CLI installed and set up with proper IAM credentials, see https://osu-sustainability-office.github.io/docs/backend_prereqs#aws
+    - Output filename format: "formatted-" (if applicable) + last event timestamp (in unix) + "-" + container name ("/" replaced with "_" to avoid file naming errors)
+      - When sorted alphabetically, most recent logs will be at bottom. Timestamps in filename can be checked with https://www.unixtimestamp.com/index.php, and the rest of the filename can be checked with the log stream names as they appear on cloudwatch web interface
+      - "formatted-" strips the timestamps on each line and trailing whitespace to improve readability. The original (non formatted) log files are also kept if needed (e.g. to double check how long it took for a process to execute)
 ## Deprecated
 
 - **TeslaSolarCity** (Not Deployed): This webscraper is deprecated due to Tesla deprecation of service, now we are using iframes on a different public endpoint also provided by Tesla.

--- a/README.md
+++ b/README.md
@@ -53,9 +53,9 @@ Similarly, any files listed should be assumed to be located within the directory
     - Retrieves most recent cloudwatch logs from a given ECS container via the AWS CLI, to save time having to deal with AWS website interface, and to make it easier to download log files to managers when needed
     - The exact amount of logs, and which ECS container, can be configured in the variables at the top of `retrieveLogs` file
     - Must have AWS CLI installed and set up with proper IAM credentials, see https://osu-sustainability-office.github.io/docs/backend_prereqs#aws
-    - Output filename format: "formatted-" (if applicable) + last event timestamp (in unix) + "-" + container name ("/" replaced with "_" to avoid file naming errors)
+    - Output filename format: `formatted-` (if applicable) + last event timestamp (in unix) + `-` + container name (`/` replaced with `_` to avoid file naming errors)
       - When sorted alphabetically, most recent logs will be at bottom. Timestamps in filename can be checked with https://www.unixtimestamp.com/index.php, and the rest of the filename can be checked with the log stream names as they appear on cloudwatch web interface
-      - "formatted-" strips the timestamps on each line and trailing whitespace to improve readability. The original (non formatted) log files are also kept if needed (e.g. to double check how long it took for a process to execute)
+      - `formatted-` in the output filenames means that timestamps and trailing whitespace on each line have been removed to improve readability. The original (non-formatted) log files are also kept if needed (e.g. to double check how long it took for a process to execute)
 ## Deprecated
 
 - **TeslaSolarCity** (Not Deployed): This webscraper is deprecated due to Tesla deprecation of service, now we are using iframes on a different public endpoint also provided by Tesla.

--- a/cloudwatch-cli/fetchLogs.js
+++ b/cloudwatch-cli/fetchLogs.js
@@ -1,7 +1,7 @@
 const LOG_AMOUNT = 5;
 
 // see all ecs containers: aws logs describe-log-groups --log-group-name-prefix "/ecs"
-const ECS_CONTAINER = "/ecs/collect-check-acq";
+const ECS_CONTAINER = "/ecs/collect-ennex-data";
 // manually get stream info (example): aws logs describe-log-streams --log-group-name "/ecs/collect-check-acq" --order-by LastEventTime --descending
 // manually get logs for specific stream (example): aws logs get-log-events --log-group-name /ecs/collect-check-acq --log-stream-name ecs/check-acq-container/4379d84b43f04b188c97017de0f09bc3 --output text > a.log
 
@@ -25,7 +25,7 @@ for (let i = 0; i < recentStreams.length; i++) {
     "-" +
     recentStreams[i].logStreamName.replace(/\//g, "_");
   execSync(
-    `aws logs get-log-events --log-group-name ${ECS_CONTAINER} --log-stream-name ${recentStreams[i].logStreamName} --output text > ${replacedString}.log`
+    `aws logs get-log-events --log-group-name ${ECS_CONTAINER} --log-stream-name ${recentStreams[i].logStreamName} --start-time ${recentStreams[i].firstEventTimestamp} --end-time ${recentStreams[i].lastIngestionTime} --output text > ${replacedString}.log`
   );
   inputFileNames.push(`${replacedString}.log`);
 }

--- a/cloudwatch-cli/fetchLogs.js
+++ b/cloudwatch-cli/fetchLogs.js
@@ -1,0 +1,73 @@
+const LOG_AMOUNT = 5;
+
+// see all ecs containers: aws logs describe-log-groups --log-group-name-prefix "/ecs"
+const ECS_CONTAINER = "/ecs/collect-check-acq";
+// manually get stream info (example): aws logs describe-log-streams --log-group-name "/ecs/collect-check-acq" --order-by LastEventTime --descending
+// manually get logs for specific stream (example): aws logs get-log-events --log-group-name /ecs/collect-check-acq --log-stream-name ecs/check-acq-container/4379d84b43f04b188c97017de0f09bc3 --output text > a.log
+
+// When output files are sorted alphabetically A-Z (ascending), the log file at the bottom is most recent log file
+
+const fs = require("fs");
+const { execSync } = require("child_process");
+let getStreams = execSync(
+  `aws logs describe-log-streams --log-group-name ${ECS_CONTAINER} --order-by LastEventTime --descending`
+);
+// console.log(test.toString())
+console.log(JSON.parse(getStreams.toString()).logStreams.slice(0, LOG_AMOUNT));
+let recentStreams = JSON.parse(getStreams.toString()).logStreams.slice(
+  0,
+  LOG_AMOUNT
+);
+let inputFileNames = [];
+for (let i = 0; i < recentStreams.length; i++) {
+  const replacedString =
+    recentStreams[i].lastEventTimestamp +
+    "-" +
+    recentStreams[i].logStreamName.replace(/\//g, "_");
+  execSync(
+    `aws logs get-log-events --log-group-name ${ECS_CONTAINER} --log-stream-name ${recentStreams[i].logStreamName} --output text > ${replacedString}.log`
+  );
+  inputFileNames.push(`${replacedString}.log`);
+}
+function removeFirstLineAndTimestamps(inputFile) {
+  fs.readFile(inputFile, "utf8", (err, data) => {
+    if (err) {
+      console.error("Error reading file:", err);
+      return;
+    }
+
+    // Split the file content into lines
+    const lines = data.split("\n");
+
+    // Remove the first line
+    lines.shift();
+
+    // Remove timestamps and "EVENTS" from each line
+    const modifiedLines = lines.map((line) => {
+      // Remove 13 digit Unix timestamps
+      const timestampRegex = /\s?\b\d{13}\b\s?/g;
+      line = line.replace(timestampRegex, "");
+
+      // Remove "EVENTS"
+      line = line.replace(/EVENTS/g, "");
+
+      return line.trimEnd(); // Trim any leading/trailing whitespace
+    });
+
+    // Join the modified lines back together
+    const modifiedContent = modifiedLines.join("\n");
+
+    // Write the modified content back to the file
+    fs.writeFile("formatted-" + inputFile, modifiedContent, "utf8", (err) => {
+      if (err) {
+        console.error("Error writing file:", err);
+        return;
+      }
+      console.log("File processing completed successfully.");
+    });
+  });
+}
+
+for (let i = 0; i < inputFileNames.length; i++) {
+  removeFirstLineAndTimestamps(inputFileNames[i]);
+}


### PR DESCRIPTION
![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/82061589/9b2c5906-00bf-41e2-94e6-090acc685a60)

Retrieve and format cloudwatch logs through cli to save time in case of future email alerts etc. See README and code comments for details.

Potential TODO: 
- Add command line arguments for different container names / log amounts
- Add Unix to GMT (or PST) human-readable date conversion