### PR TITLE
deliver error logging and other logging fixes

### DIFF
--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -55,7 +55,8 @@ let loggedInFlag = false;
 let graphButton = "";
 let first_selector_num = 0;
 let PPArray = [];
-let unAvailableArray = [];
+let unAvailableErrorArray = [];
+let deliveredErrorArray = [];
 let otherErrorArray = [];
 let wrongDateArray = [];
 let yearlyArray = [];
@@ -67,6 +68,7 @@ let continueMeters = 0;
 let continueVarLoading = 0;
 let continueVarMonthly = 0;
 let page = "";
+let pp_meter_id = "";
 
 (async () => {
   // Launch the browser
@@ -348,7 +350,7 @@ let page = "";
 
           let positionMeter = "(Meter #";
           let meterStringIndex = pp_meter_full_trim.indexOf(positionMeter);
-          let pp_meter_id = parseInt(
+          pp_meter_id = parseInt(
             pp_meter_full_trim.slice(
               meterStringIndex + 8,
               pp_meter_full_trim.length - 2,
@@ -486,7 +488,23 @@ let page = "";
             );
             meter_selector_num++;
             continueVarLoading = 0;
-            unAvailableArray.push({ meter_selector_num, pp_meter_id });
+            unAvailableErrorArray.push({ meter_selector_num, pp_meter_id });
+            continue;
+          }
+
+          // potential TODO: If delivered error, get second row of data
+          // Then need to handle potential redundant data on upload, first of month case
+          // Difference between delivered error and just wrong date is that unavailable shows expected
+          // date (e.g. yesterday), just that the usage seems to be completely wrong values
+          if (
+            monthly_top_text.includes("delivered to you" || "received from you")
+          ) {
+            console.log(
+              "Unavailable Usage (kwh) data for monthly time range, skipping to next meter",
+            );
+            meter_selector_num++;
+            continueVarLoading = 0;
+            deliveredErrorArray.push({ meter_selector_num, pp_meter_id });
             continue;
           }
 
@@ -588,7 +606,10 @@ let page = "";
   const pacificPowerMeters = "pacific_power_data";
 
   for (let i = 0; i < PPArray.length; i++) {
-    console.log(PPArray[i]);
+    // No need to log the data twice if uploading
+    if (process.argv.includes("--no-upload")) {
+      console.log(PPArray[i]);
+    }
 
     // to prevent uploading data to API: node readPP.js --no-upload
     if (!process.argv.includes("--no-upload")) {
@@ -606,7 +627,6 @@ let page = "";
           console.log(
             `RESPONSE: ${res.status}, TEXT: ${res.statusText}, DATA: ${res.data}`,
           );
-          console.log(`uploaded ${pacificPowerMeters} data to API`);
         })
         .catch((err) => {
           console.log(err);
@@ -622,13 +642,25 @@ let page = "";
       " PST",
   );
   console.log("\nWrong Date Meters (Monthly): ");
-  console.log(wrongDateArray);
+  for (let i = 0; i < wrongDateArray.length; i++) {
+    console.log(wrongDateArray[i]);
+  }
   console.log("\nUnavailable Meters (Monthly): ");
-  console.log(unAvailableArray);
+  for (let i = 0; i < unAvailableErrorArray.length; i++) {
+    console.log(unAvailableErrorArray[i]);
+  }
+  console.log("\nDelivered Error Meters (Monthly): ");
+  for (let i = 0; i < deliveredErrorArray.length; i++) {
+    console.log(deliveredErrorArray[i]);
+  }
   console.log("\nYearly Meters: ");
-  console.log(yearlyArray);
+  for (let i = 0; i < yearlyArray.length; i++) {
+    console.log(yearlyArray[i]);
+  }
   console.log("\nOther Errors: ");
-  console.log(otherErrorArray);
+  for (let i = 0; i < otherErrorArray.length; i++) {
+    console.log(otherErrorArray[i]);
+  }
 
   // node readPP.js --save-output
   if (
@@ -638,7 +670,7 @@ let page = "";
     PPArray.push("Wrong Date Meters (Monthly): ");
     PPArray.push(wrongDateArray);
     PPArray.push("Unavailable Meters (Monthly): ");
-    PPArray.push(unAvailableArray);
+    PPArray.push(unAvailableErrorArray);
     PPArray.push("Yearly Meters: ");
     PPArray.push(yearlyArray);
     PPArray.push("Other Errors: ");

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -497,7 +497,8 @@ let pp_meter_id = "";
           // Difference between delivered error and just wrong date is that unavailable shows expected
           // date (e.g. yesterday), just that the usage seems to be completely wrong values
           if (
-            monthly_top_text.includes("delivered to you" || "received from you")
+            monthly_top_text.includes("delivered to you") ||
+            monthly_top_text.includes("received from you")
           ) {
             console.log(
               "Unavailable Usage (kwh) data for monthly time range, skipping to next meter",


### PR DESCRIPTION
## Issue
https://github.com/OSU-Sustainability-Office/automated-jobs/issues/45

## Delivered Error
The meter with Pacific Power meter ID 74364616 showed this for March 6th Cloudwatch (Cloudwatch job running on March 6th, checking March 5th meter data):
- `Period2024-03-05Average Temperature37.5kWh delivered to you207.08kWh received from you273.21Est. Rounded AmountNA`

The actual PacificPower meter data (usage kwh) for March 5th later turned out to be `836.10`.

So I am concluding that `delivered to you`, `received from you` is an error for future reference.

### Changed Code
- To account for the new "delivered error", I added a new error category for it on the scraper

## TypeError Cause
- [This catch block](https://github.com/OSU-Sustainability-Office/automated-jobs/blob/main/PacificPower/readPP.js#L569) is supposed to allow the scraper to keep running, with up to a max of 5 errors for the entire scraper's runtime.
- Due to a mistake in how `pp_meter_id` was initialized (my bad, due to refactoring the variables at the last minute before merge without sufficient testing), `pp_meter_id` was undefined in the catch block

### Changed Code
- I defined pp_meter_id with a more global scope to fix the typeError, now the catch block works as intended for "general errors"
  - To test this, you can intentionally trip an error as [explained here](https://github.com/OSU-Sustainability-Office/automated-jobs/blob/main/PacificPower/readPP.js#L466)

## Other Changes
- Add for loops to logging the error arrays, to ensure each element is logged
  - ![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/82061589/1c9f0eaa-6b0e-421f-8738-607d8c2e2520)
- Add some conditional checking to avoid logging data twice when uploading

## Misc
- To speed up looking through old Cloudwatch entries while debugging (since each PacificPower log can (currently) be up to 4k lines long)
  - Use Log Insights (reminder, see below)
  - https://github.com/OSU-Sustainability-Office/automated-jobs/pull/43#issuecomment-1956161980
  - In addition, you may need to add `| sort @timstamp asc` and `| limit 3000` 
  - ![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/82061589/6acf009f-3935-4561-bac8-f69a1e70f61e)
    - See "Info" as highlighted for more info on Log Insights query syntax

## TODO
- Depending on how handling missing data uploads is handled (https://github.com/OSU-Sustainability-Office/automated-jobs/issues/42), the "unavailable", "wrong date", "delivered" errors etc. may need to handle uploading valid data from a day earlier
  - Probably should be moved to a new PR
- Sometime need to update the wiki on Log Insights stuff