### PR TITLE
Pacific Power Meter Exclusions

### DIFF
--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -122,9 +122,12 @@ async function addNewMetersToDatabase() {
       },
     })
       .then((res) => {
-        console.log(
-          `RESPONSE: ${res.status}, TEXT: ${res.statusText}, DATA: ${res.data}`,
-        );
+        console.log(`\nRESPONSE: ${res.status}, TEXT: ${res.statusText}`);
+        if (res.status === 200) {
+          console.log(
+            `${pp_meters_exclude_not_found[i]} uploaded to database.`,
+          );
+        }
       })
       .catch((err) => {
         console.log(err);
@@ -142,12 +145,6 @@ async function addNewMetersToDatabase() {
       if (res.status < 200 || res.status >= 300) {
         throw new Error("Failed to fetch PP Meter Exclusion List");
       }
-
-      console.log(
-        `RESPONSE: ${res.status}, TEXT: ${
-          res.statusText
-        }, DATA: ${JSON.stringify(res.data)}`,
-      );
       return res.data;
     })
     .catch((err) => {
@@ -155,7 +152,9 @@ async function addNewMetersToDatabase() {
     });
 
   if (pp_meters_exclusion_list) {
-    console.log("PP Meter Exclusion List: ", pp_meters_exclusion_list);
+    console.log(
+      `${pp_meters_exclusion_list.length} meters in Meter Exclusion List`,
+    );
   } else {
     console.log(
       "Could not get PP Meter Exclusion List. All meter data will be uploaded.",
@@ -723,7 +722,9 @@ async function addNewMetersToDatabase() {
       })
         .then((res) => {
           console.log(
-            `RESPONSE: ${res.status}, TEXT: ${res.statusText}, DATA: ${res.data}`,
+            `RESPONSE: ${res.status}, TEXT: ${
+              res.statusText
+            }, DATA: ${JSON.stringify(res.data)}`,
           );
         })
         .catch((err) => {
@@ -767,9 +768,12 @@ async function addNewMetersToDatabase() {
   for (let i = 0; i < pp_meters_include.length; i++) {
     console.log(pp_meters_include[i]);
   }
-  console.log("\nMeters Not Found in Exclusion List (new meters): ");
-  for (let i = 0; i < pp_meters_exclude_not_found.length; i++) {
-    console.log(pp_meters_exclude_not_found[i]);
+
+  if (pp_meters_exclude_not_found.length > 0) {
+    console.log("\nMeters Not Found in Exclusion List (new meters): ");
+    for (let i = 0; i < pp_meters_exclude_not_found.length; i++) {
+      console.log(pp_meters_exclude_not_found[i]);
+    }
   }
 
   // add new meters to exclusion table in database if uploading

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -703,10 +703,7 @@ async function addNewMetersToDatabase() {
   const pacificPowerMeters = "pacific_power_data";
 
   for (let i = 0; i < PPArray.length; i++) {
-    // No need to log the data twice if uploading
-    if (process.argv.includes("--no-upload")) {
-      console.log(PPArray[i]);
-    }
+    console.log(PPArray[i]);
 
     // to prevent uploading data to API: node readPP.js --no-upload
     if (!process.argv.includes("--no-upload")) {
@@ -721,11 +718,10 @@ async function addNewMetersToDatabase() {
         },
       })
         .then((res) => {
-          console.log(
-            `RESPONSE: ${res.status}, TEXT: ${
-              res.statusText
-            }, DATA: ${JSON.stringify(res.data)}`,
-          );
+          console.log(`RESPONSE: ${res.status}, TEXT: ${res.statusText}`);
+          if (res.status === 200) {
+            console.log(`${PPArray[i].pp_meter_id} uploaded to database.`);
+          }
         })
         .catch((err) => {
           console.log(err);

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -559,6 +559,14 @@ async function addNewMetersToDatabase() {
           let positionUsage = "Usage(kwh)"; // You can edit this value to something like "Usage(kwhdfdfd)" to test the catch block at the end
           let positionEst = "Est. Rounded";
 
+          // Custom breakpoint for testing
+          /*
+          if (meter_selector_num === 518) {
+            continueMetersFlag = true;
+            break;
+          }
+          */
+
           if (monthly_top_text.includes(positionEst)) {
             console.log("Data is not yearly. Data is probably monthly.");
           } else {
@@ -668,14 +676,6 @@ async function addNewMetersToDatabase() {
           } else {
             PPArray.push(PPTable);
           }
-
-          /* // for testing json output
-      if (newID === 511) {
-        continueMetersFlag = true;
-  
-        break;
-      }
-      */
 
           // If "Est. Rounded" is found, then the data is monthly.
           if (monthly_top_text.includes(positionEst)) {


### PR DESCRIPTION
Changes
---
An API request is sent at the start of the scraper to retrieve all meters in the `pacific_power_exclusion` table. 
If a meter is in the list with an `exclude` value of `yes`, the data for that meter will not be sent to the database. 
If a meter has a value of `no` or is not in the list, the data will be sent. For now, if the meter is not in the list, there is a console log indicating that it's a new meter.

Testing
---
* Run the Energy Dashboard backend locally
* Set the scraper `env` file `DASHBOARD_API` value to http://127.0.0.1:3000 
* Run with the --no-upload flag and the --save-output flag to make it easier to read the data, although this one isn't required
  * `node readPP.js --no-upload --save-output`

TODO
---
* Add a POST endpoint to the Energy Dashboard to add new meters to the database
* Add logic in the scraper for uploading newly found meters to the database via the new endpoint
* Finalize `pacific_power_exclusion` table format/naming 
  * Do we want to have monthly/yearly data meters excluded? If we do and they start having daily data, we won't get notified unless we add more logic. Potentially ask Brandon/Lety about this. 
* Add the rest of the existing meters to the table (there are currently only two meters in the database for testing, one to exclude and one not to exclude, both with daily data)
* Remove extra console logs used for testing
