### PR TITLE
Fix Monthly Timeframes

### DIFF
--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -1,5 +1,6 @@
-// TODO: Add comments on all the iterators (continueVarMonthly etc) to make them easier to keep track of
+// TODO (IN PROGRESS): Add comments on all the iterators (continueVarMonthly etc) to make them easier to keep track of
 // TODO (IN PROGRESS): Enforce a consistent "DEBUG: " comment syntax
+// TODO comments below about renaming variables will probably go to a separate PR (unless it is a new variable added by this PR)
 
 // Local Testing (TODO: Move to README later): node readPP.js --no-upload > logs/something.txt
 

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -588,6 +588,9 @@ async function addNewMetersToDatabase() {
               }
             } catch (error) {
               // console.error(error);
+
+              // TODO: Should the "Monthly Top Not Found" messages be tweaked / hidden in case of an intentional throw
+              // ("throwing for odd timeframeIterator, not reading this value although it is valid")?
               console.log(`Monthly Top not found.`);
 
               // open up time menu and switch timeframes (month vs year etc) to avoid the "no data" (when there actually is data) glitch
@@ -663,6 +666,8 @@ async function addNewMetersToDatabase() {
           // This increases in value every time we try to read a given meter's data (assuming scraper got past loading screen check)
           timeframeIterator++;
           if (continueVarMonthlyFlag) {
+            // TODO: Should the "Monthly Top Not Found" messages be tweaked / hidden in case of an intentional throw
+            // ("throwing for odd timeframeIterator, not reading this value although it is valid")?
             console.log("Monthly Top not found, try again");
             console.log(
               "Attempt " +

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -475,7 +475,7 @@ async function addNewMetersToDatabase() {
         try {
           console.log("\n" + meter_selector_num.toString());
 
-          // After the first time a loading screen is detected for a meter, don't need to check again
+          // After the first time a loading screen is detected, don't need to open meter menu again (for current meter ID)
           if (continueVarLoading === 0) {
             await page.waitForFunction(
               () =>

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -609,7 +609,7 @@ async function addNewMetersToDatabase() {
                 timeout: 25000,
               });
               if (weekCheck) {
-                console.log("One Week Option Found");
+                console.log("One Week Option Found, Data is probably monthly");
 
                 // odd timeframeIterator (0,2,4, etc) = One Month
                 timeframeChoices = [

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -590,7 +590,7 @@ async function addNewMetersToDatabase() {
               // console.error(error);
               console.log(`Monthly Top not found.`);
 
-              // return to the previous meter and start again, seems only way to avoid the "no data" (when there actually is data) glitch
+              // open up time menu and switch timeframes (month vs year etc) to avoid the "no data" (when there actually is data) glitch
               // trying to reload the page is a possibility but it's risky due to this messing with the mat-option ID's
               continueVarMonthlyFlag = true;
               await page.waitForSelector(TIME_MENU);


### PR DESCRIPTION
## Issue
- https://github.com/OSU-Sustainability-Office/automated-jobs/issues/55

## Changes
- Old timeframe switching logic for monthly-type meters (to try to get data to load):
  - 1 Week > 1 Month > repeat
- New timeframe switching logic for monthly-type meters:
  - 1 Year > 1 Month > 2 Years > 1 Month > 1 Day > 1 Month > 1 Week > 1 Month > repeat 
- The timeframe logic for yearly-type meters should be the same as it was:
  - 2 Year > 1 Year > repeat
- Also fixed issue with meter menu opening logic (stop opening meter menu for the current meter, once current meter showed loading screen successfully)
- Tried to do some comment cleanup (maybe save variable renaming and bigger refactors for another PR?)

## TODOS
- [ ] More testing of the script at various times of day to see if the changes make the scraper more robust to errors
- [ ] Comment / logs cleanup
- [ ] Any other issues or fixes that come up for the timeframe issue
  - For instance, there's probably a better data structure or control flow for the monthly list of timeframes that doesn't involve just repeating "1 month" 4 times but I just went with the first solution that worked
  - Not sure if increasing `maxAttempts` from 5 to 8 across the board is ideal (although it would improve reliability in general). It could be an option to make multiple "maxAttempts" variables for different events (e.g. max of 5 attempts for login retries vs 8 for timeframe retries)
  - Should the "Monthly Top Not Found" messages be tweaked / hidden in case of an intentional throw (`throwing for odd timeframeIterator, not reading this value although it is valid`)?
- [ ] See current TODO comments in code as well (note "in progress" vs "future PR" keywords)

## Testing
I included a log excerpt below since this error (top row of meter data aka `monthly_top` not detected) triggers somewhat randomly. For more robust testing, be sure to test this several times and various times of day.

Suggested: Use command `node readPP.js --no-upload > logs/something.txt`, check back later (Ctrl F `Monthly Top not found, try again`, `Attempt ` in the text file specified)

Excerpt from my own logs below (May 21, 2024,  ~6 pm).

```
39
Meter Menu Opened
New Meter Opened
Loading Screen Found
33986 HIGHWAY 34 BYPASS CORVALLIS            OR  (Item #241)  (Meter #78831398 )
PP Meter ID: 78831398
Monthly Top not found.
One Week Option Found
One Year Found
One Year Clicked
Monthly Top not found, try again
Attempt 1 of 8

39
Meter Menu Opened
New Meter Opened
Loading Screen not found.
Loading Screen not found, trying again

39
33986 HIGHWAY 34 BYPASS CORVALLIS            OR  (Item #241)  (Meter #78831398 )
PP Meter ID: 78831398
Monthly Top Found
throwing for odd timeframeiterator, not reading this value although valid
Monthly Top not found.
One Week Option Found
One Month Found
One Month Clicked
Monthly Top not found, try again
Attempt 2 of 8

39
33986 HIGHWAY 34 BYPASS CORVALLIS            OR  (Item #241)  (Meter #78831398 )
PP Meter ID: 78831398
Monthly Top Found
Monthly Data Top Row Found, getting table top row value
Data is not yearly. Data is probably monthly.
===
Period2024-05-20Average Temperature52.5Usage(kwh)51.74Est. Rounded Amount$8
```