### PR TITLE
Fix parseFloat bug

### DIFF
--- a/ennex-os/readEnnex.js
+++ b/ennex-os/readEnnex.js
@@ -260,6 +260,8 @@ const meterlist = require("./meterlist.json");
           (el) => el.innerText,
           lastMonthReading,
         );
+        // remove any commas if they exist so that parseFloat can handle values over 1,000
+        totalYieldYesterday = totalYieldYesterday.replace(/,/g, "");
         console.log(totalYieldYesterday);
 
         let [lastDate] = await page.$x(


### PR DESCRIPTION
See issue #62. The function `parseFloat` will remove any numbers after a comma, so `"1,200.45"` would become `1`. 

Before
---
![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/102624422/3018e3d6-f5f3-4c3e-8848-0728ebe71926)


After
---
![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/102624422/b1c7d24b-38a9-46a0-83a3-c204c55a9d5f)

Under 1,000
---
![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/102624422/35049698-bfdf-4616-92b8-fbb7c26f96d0)


Testing
---
As long as yesterday's OSU Operations meter had a value over 1,000, you can run it as normal, otherwise you'll need to change the date by setting `ENNEX_DAY` to some previous day [here](https://github.com/OSU-Sustainability-Office/automated-jobs/blob/main/ennex-os/readEnnex.js#L87). To test a value lower than 1,000, use `ENNEX_DAY = 04;` as June 04 is the last day below 1,000. 