### PR TITLE
Add Pacific Power Meter ID to output

### DIFF
--- a/check-acq/check-acq.js
+++ b/check-acq/check-acq.js
@@ -73,6 +73,10 @@ axios
             let meterObject = {
               meter_id: parseInt(buildings.meterGroups[i].meters[j].id),
               meter_name: buildings.meterGroups[i].meters[j].name,
+              pacific_power_meter_id:
+                buildings.meterGroups[i].meters[j].pacificPowerID === null
+                  ? "N/A"
+                  : buildings.meterGroups[i].meters[j].pacificPowerID,
               building_id: parseInt(buildings.id),
               building_name: buildings.name,
               meterGroups: [
@@ -120,6 +124,9 @@ axios
               if (!allMeters.some(checkDupMeter)) {
                 delete foundBlacklistMeter.meter_name;
                 foundBlacklistMeter.meter_name = meterObject.meter_name;
+                delete foundBlacklistMeter.pacific_power_meter_id;
+                foundBlacklistMeter.pacific_power_meter_id =
+                  meterObject.pacificPowerID;
                 delete foundBlacklistMeter.building_id;
                 foundBlacklistMeter.building_id = meterObject.building_id;
                 delete foundBlacklistMeter.building_name;
@@ -199,6 +206,7 @@ axios
           let expandedMeterObject = {
             meter_id: parseInt(allMeters[i].meter_id),
             meter_name: allMeters[i].meter_name,
+            pacific_power_meter_id: allMeters[i].pacific_power_meter_id,
             building_id: allMeters[i].building_id,
             building_name: allMeters[i].building_name,
             meterGroups: allMeters[i].meterGroups,


### PR DESCRIPTION
The Pacific Power ID was added to the `allbuildings` endpoint in [this PR](https://github.com/OSU-Sustainability-Office/energy-dashboard/pull/333), so I've added the Pacific Power Meter ID to the `check-acq` output for easier debugging. If it's not a Pacific Power Meter it will say "N/A" instead of a meter ID. 

Before
---
![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/102624422/8408e159-9679-4b07-92b5-a3793caa82d8)


After
---
![image](https://github.com/OSU-Sustainability-Office/automated-jobs/assets/102624422/8b36d8c7-1172-4971-9e5d-1501f8009a9b)
