### PR TITLE
Fixed Pacific Power meters not triggering 'no recent data' in Cloudwatch

### DIFF
--- a/check-acq/check-acq.js
+++ b/check-acq/check-acq.js
@@ -269,15 +269,15 @@ axios
                   if (parsedData.length > 0) {
                     const timeValues = [];
 
-                    // 7 days (604800 seconds) minimum cutoff for "missing data" / "nochange data", for Pacific Power meters
+                    // 6 days (518400 seconds) minimum cutoff for "missing data" / "nochange data", for Pacific Power meters
                     // 3 days (259200 seconds) minimum cutoff for "missing data" / "nochange data", for all other meters
                     const minDate =
-                      batchedMeterObject.classInt === 9990002 ? 604800 : 259200;
+                      batchedMeterObject.classInt === 9990002 ? 518400 : 259200;
 
-                    // 8 days (691200 seconds) minimum cutoff for "missing data" / "nochange data", for Pacific Power meters
+                    // 9 days (777600 seconds) minimum cutoff for "missing data" / "nochange data", for Pacific Power meters
                     // 4 days (345600 seconds) minimum cutoff for "missing data" / "nochange data", for all other meters
                     const maxDate =
-                      batchedMeterObject.classInt === 9990002 ? 691200 : 345600;
+                      batchedMeterObject.classInt === 9990002 ? 777600 : 345600;
 
                     for (const obj of parsedData) {
                       timeValues.push(obj.time);
@@ -291,7 +291,7 @@ axios
                     /*
                         The first data point and its timestamp are checked. If the first data point is older than 3 days, it is
                         considered "missing", and anything between 3 and 4 days (259200 to 345600 seconds), or between 7 and 8
-                        days for Pacific Power meters (604800 to 691200 seconds) is also flagged as "recent" missing data
+                        days for Pacific Power meters (518400 to 777600 seconds) is also flagged as "recent" missing data
                         */
                     let timeDifferenceNoData = "";
                     if (dataValues[0] || dataValues[0] === 0) {
@@ -301,7 +301,7 @@ axios
                       );
                     }
                     // uncomment for debug (test "no data value" slightly over 3 days, vs over 4 days)
-                    // or test "no data value" slightly over 7 days, vs over 8 days, for Pacific Power meters
+                    // or test "no data value" slightly over 6 days, vs over 9 days, for Pacific Power meters
                     /*
                         if (batchedMeterObject.meter_id === 1) {
                           timeDifferenceNoData = 269200;
@@ -463,7 +463,7 @@ axios
                     }
                     /* 
                         the first data point with a measurement different from the first datapoint is checked. If the timestamp
-                        is older than 3 days (or over 7 days for PacificPower meters), it is considered "non-changing". If no data values different from the first
+                        is older than 3 days (or over 6 days for PacificPower meters), it is considered "non-changing". If no data values different from the first
                         datapoint are found, it is assumed the data is identical for the total time period of the previous 2 months
                         */
                     let timeDifferenceNoChange = "";


### PR DESCRIPTION
Check-acq runs every two days to check for missing data, and since Pacific Power only runs once a day, when we had a meter lose data it skipped triggering the `Meters with no data (recent)` log and went straight to `Meters with no data (for a long time)`, so we didn't get an SNS alert. The acquisuite meters upload data every 15 minutes, so they don't have the issue of a smaller time frame of 1 day. I've expanded Pacific Power meter's min/max dates by one on either side, so it now has a three day window. It can be tested by changing a meter's timeDifferenceNoData to be after 6 days and before 8 days after it's set on [this line](https://github.com/OSU-Sustainability-Office/automated-jobs/blob/1f2e309427784209d04d58fdb6a983523f0bd2d4/check-acq/check-acq.js#L297) :

```
if (batchedMeterObject.meter_id === 153) {
     timeDifferenceNoData = 604800;
}
```

Result:
![image](https://github.com/user-attachments/assets/35557491-39f7-4a92-97c8-c5470a0b80fe)
Note that we might want to change `Meters with no data (for a long time)` back to how it was originally (`Meters with no data`) as it's a little confusing for a meter to be under both, but that can be done with the refactor later. 