### PR TITLE
Add flags

### DIFF
--- a/PacificPower/README.md
+++ b/PacificPower/README.md
@@ -2,14 +2,18 @@
 
 Retrieves energy data for several meters from Pacific Power website. Runs once every day, and checks the database for the last 7 days worth of data to upload any missing days for each meter. It also checks the database for a meter exclusion list, as there are many meters on the website that we don't want to upload data for. If it encounters a new meter, it uploads it to the database with a status of `new`. Emails alerts integrated for new meters and failed uploads.
 
-- `node readPP.js --save-output --no-upload --headful`
+- `node readPP.js --save-output --no-upload --headful --local-api`
   - `--no-upload` Optional argument. Runs the webscraper as normal but does not upload any meter data or new meters to the database.
   - `--save-output` Optional argument. Saves all of the meter data that is logged to the console into a JSON file `output.json` to make it easier to read.
   - `--headful` Optional argument for debugging. Runs the browser in headful mode, meaning that you can see the browser. Without this flag, the browser isn't visible. [Reference](https://developer.chrome.com/docs/chromium/new-headless).
+  - `--local-api` Optional argument. Must be running the [Energy Dashboard](https://github.com/OSU-Sustainability-Office/energy-dashboard) backend locally, and the scraper will use the localhost API instead of the production API.
 
 ### Debugging
 
 There are various comments and code commented out throughout `readPP.js` that are helpful when debugging, they can be found by searching for `debug` in the code.
+Another helpful way to debug is to output all console logs into a text file to make it easy to read and search for specific keywords. Make sure you have a `logs` folder in the directory:
+
+- `node readPP.js > logs/output.txt`
 
 ### Formatting
 

--- a/PacificPower/README.md
+++ b/PacificPower/README.md
@@ -2,9 +2,10 @@
 
 Retrieves energy data for several meters from Pacific Power website. Runs once every day, and checks the database for the last 7 days worth of data to upload any missing days for each meter. It also checks the database for a meter exclusion list, as there are many meters on the website that we don't want to upload data for. If it encounters a new meter, it uploads it to the database with a status of `new`. Emails alerts integrated for new meters and failed uploads.
 
-- `node readPP.js --save-output --no-upload`
+- `node readPP.js --save-output --no-upload --headful`
   - `--no-upload` Optional argument. Runs the webscraper as normal but does not upload any meter data or new meters to the database.
   - `--save-output` Optional argument. Saves all of the meter data that is logged to the console into a JSON file `output.json` to make it easier to read.
+  - `--headful` Optional argument for debugging. Runs the browser in headful mode, meaning that you can see the browser. Without this flag, the browser isn't visible. [Reference](https://developer.chrome.com/docs/chromium/new-headless).
 
 ### Debugging
 

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -1151,7 +1151,9 @@ async function getMeterData() {
 
   // Launch the browser
   const browser = await puppeteer.launch({
-    headless: "new", // DEBUG: set to false (no quotes) for testing. Leave as "new" (with quotes) for production | reference: https://developer.chrome.com/articles/new-headless/
+    // DEBUG: use --headful flag (node readPP.js --headful), browser will be visible
+    // reference: https://developer.chrome.com/articles/new-headless/
+    headless: process.argv.includes("--headful") ? false : "new",
     args: ["--no-sandbox"],
     // executablePath: 'google-chrome-stable'
   });

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -2,8 +2,6 @@
 // TODO (IN PROGRESS): Enforce a consistent "DEBUG: " comment syntax
 // TODO comments below about renaming variables will probably go to a separate PR (unless it is a new variable added by this PR)
 
-// Local Testing (TODO: Move to README later): node readPP.js --no-upload > logs/something.txt
-
 // https://pptr.dev/guides/evaluate-javascript
 
 // total runtime with current parameters: As fast as 4 minutes not counting last noData checks, or 9 minutes with noData checks
@@ -23,6 +21,9 @@ const TIMEOUT_BUFFER = 1200000; // Currently set for 20 minutes (1,200,000 ms), 
 const axios = require("axios");
 const fs = require("fs");
 const maxAttempts = 8; // needs to be at least 8 with current code because we check these timeframes (monthly): [2 year, 1 month, 1 year, 1 month, 1 day, 1 month, 1 week, 1 month]
+const DASHBOARD_API = process.argv.includes("--local-api")
+  ? process.env.LOCAL_API
+  : process.env.DASHBOARD_API;
 
 // PacificPower Selectors (chrome debug instructions: inspect element > element > copy selector / Xpath)
 const ACCEPT_COOKIES = "button.cookie-accept-button";
@@ -757,7 +758,7 @@ async function addNewMetersToDatabase() {
   for (let i = 0; i < pp_meters_exclude_not_found.length; i++) {
     await axios({
       method: "post",
-      url: `${process.env.DASHBOARD_API}/ppupload`,
+      url: `${DASHBOARD_API}/ppupload`,
       data: {
         id: pp_meters_exclude_not_found[i],
         pwd: process.env.API_PWD,
@@ -785,7 +786,7 @@ async function addNewMetersToDatabase() {
 async function getPacificPowerRecentData() {
   let recent_data = await axios({
     method: "get",
-    url: `${process.env.DASHBOARD_API}/pprecent`,
+    url: `${DASHBOARD_API}/pprecent`,
   })
     .then((res) => {
       // DEBUG: change to test specific status codes from API
@@ -830,7 +831,7 @@ async function getPacificPowerRecentData() {
 async function getPacificPowerMeterExclusionList() {
   let exclusion_list = await axios({
     method: "get",
-    url: `${process.env.DASHBOARD_API}/ppexclude`,
+    url: `${DASHBOARD_API}/ppexclude`,
   })
     .then((res) => {
       // DEBUG: change to test specific status codes from API
@@ -864,7 +865,7 @@ async function uploadDatatoDatabase(meterData) {
 
   await axios({
     method: "post",
-    url: `${process.env.DASHBOARD_API}/upload`,
+    url: `${DASHBOARD_API}/upload`,
     data: {
       id: pacificPowerMeters,
       body: meterData,

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -1,5 +1,3 @@
-// TODO (IN PROGRESS): Add comments on all the iterators (monthlyDataTopRowError etc) to make them easier to keep track of
-// TODO (IN PROGRESS): Enforce a consistent "DEBUG: " comment syntax
 // TODO comments below about renaming variables will probably go to a separate PR (unless it is a new variable added by this PR)
 
 // https://pptr.dev/guides/evaluate-javascript
@@ -179,7 +177,7 @@ async function signInToPacificPower() {
       "First time logged in, continuing to Account > Energy Usage Page",
     );
 
-    // uncomment for login error handling
+    // DEBUG: uncomment for login error handling
     // throw "testing login error handling try again";
   } else if (loginErrorCount > 0) {
     console.log("Already logged in, continuing to Account > Energy Usage Page");

--- a/SEC/README.md
+++ b/SEC/README.md
@@ -2,8 +2,9 @@
 
 Retrieves some solar panel data from Student Experience Center. Email alerts integrated for failed upload.
 
-- `node readSEC.js --no-upload`
+- `node readSEC.js --no-upload --headful`
   - `--no-upload` Optional argument. Runs the webscraper as normal but does not upload the data to the database.
+  - `--headful` Optional argument for debugging. Runs the browser in headful mode, meaning that you can see the browser. Without this flag, the browser isn't visible. [Reference](https://developer.chrome.com/docs/chromium/new-headless).
 
 ### Debugging
 

--- a/SEC/README.md
+++ b/SEC/README.md
@@ -2,9 +2,10 @@
 
 Retrieves some solar panel data from Student Experience Center. Email alerts integrated for failed upload.
 
-- `node readSEC.js --no-upload --headful`
+- `node readSEC.js --no-upload --headful --local-api`
   - `--no-upload` Optional argument. Runs the webscraper as normal but does not upload the data to the database.
   - `--headful` Optional argument for debugging. Runs the browser in headful mode, meaning that you can see the browser. Without this flag, the browser isn't visible. [Reference](https://developer.chrome.com/docs/chromium/new-headless).
+  - `--local-api` Optional argument. Must be running the [Energy Dashboard](https://github.com/OSU-Sustainability-Office/energy-dashboard) backend locally, and the scraper will use the localhost API instead of the production API.
 
 ### Debugging
 

--- a/SEC/readSEC.js
+++ b/SEC/readSEC.js
@@ -5,7 +5,9 @@
 const puppeteer = require("puppeteer");
 require("dotenv").config();
 const meterlist = require("./meterlist.json");
-
+const DASHBOARD_API = process.argv.includes("--local-api")
+  ? process.env.LOCAL_API
+  : process.env.DASHBOARD_API;
 const TIMEOUT_BUFFER = 600000; // lower to 10000 for debug
 const axios = require("axios");
 
@@ -193,7 +195,7 @@ const axios = require("axios");
     if (!process.argv.includes("--no-upload")) {
       await axios({
         method: "post",
-        url: `${process.env.DASHBOARD_API}/upload`,
+        url: `${DASHBOARD_API}/upload`,
         data: {
           id: solarmeter,
           body: PV_tableData[i],

--- a/SEC/readSEC.js
+++ b/SEC/readSEC.js
@@ -14,7 +14,9 @@ const axios = require("axios");
 
   // Launch the browser
   browser = await puppeteer.launch({
-    headless: "new", // set to false (no quotes) for debug | reference: https://developer.chrome.com/articles/new-headless/
+    // DEBUG: use --headful flag (node readSEC.js --headful), browser will be visible
+    // reference: https://developer.chrome.com/articles/new-headless/
+    headless: process.argv.includes("--headful") ? false : "new",
     args: ["--no-sandbox"],
     // executablePath: 'google-chrome-stable'
   });

--- a/SEC/readSEC.js
+++ b/SEC/readSEC.js
@@ -8,7 +8,7 @@ const meterlist = require("./meterlist.json");
 const DASHBOARD_API = process.argv.includes("--local-api")
   ? process.env.LOCAL_API
   : process.env.DASHBOARD_API;
-const TIMEOUT_BUFFER = 600000; // lower to 10000 for debug
+const TIMEOUT_BUFFER = 600000; //DEBUG: lower to 10000 for faster testing
 const axios = require("axios");
 
 (async () => {

--- a/check-acq/README.md
+++ b/check-acq/README.md
@@ -2,9 +2,10 @@
 
 Checks for Acquisuite and Pacific Power (not solar panel) meter status. Email alerts integrated for missing or unchanging data. Originally only checked for Acquisuite meters, hence the name.
 
-- `node check-acq.js --<measurement> --save-output --debug-logs`
+- `node check-acq.js --<measurement> --save-output --debug-logs --local-api`
   - `--debug-logs` Optional argument, logs various data throughout the runtime (including meter times and data). Can be found in code by searching `DEBUG:` or `--debug-logs`.
   - `--save-output` Optional argument, saves output to `check-acq/mergedFinalDataOutput.json` or `check-acq/mergedFinalDataOutput.txt` (note that this output.json file is in .gitignore, it is not tracked on remote)
+  - `--local-api` Optional argument. Must be running the [Energy Dashboard](https://github.com/OSU-Sustainability-Office/energy-dashboard) backend locally, and the scraper will use the localhost API instead of the production API.
   - `--<measurement>` Optional argument. Choose `--negative`, `--nodata`, or `--nochange`. This restricts the script to only collect info on one specified measurement of negative data, missing data (`--nodata` flag), non-changing data
     - e.g. `node check-acq.js --negative --save-output` to filter for negative data only
     - Combining this with `--save-output` will add `Negative`, `NoData`, or `NoChange` to the output file name, e.g. `check-acq/mergedFinalDataOutputNegative.json`

--- a/check-acq/check-acq.js
+++ b/check-acq/check-acq.js
@@ -35,8 +35,9 @@ let totalNoChangePoints = [];
 let totalNegPoints = [];
 let totalSomePhasesNegative = [];
 
-const apiUrl =
-  "https://api.sustainability.oregonstate.edu/v2/energy/allbuildings";
+const apiUrl = process.argv.includes("--local-api")
+  ? "http://localhost:3000/allbuildings"
+  : "https://api.sustainability.oregonstate.edu/v2/energy/allbuildings";
 
 /**
  * Cleans up the final data and logs, and saves the output to a file if the --save-output flag is included

--- a/ennex-os/README.md
+++ b/ennex-os/README.md
@@ -2,9 +2,10 @@
 
 Retrieves some solar panel data from OSU Operations. Email alerts integrated for failed upload.
 
-- `node readEnnex.js --no-upload --headful`
+- `node readEnnex.js --no-upload --headful --local-api`
   - `--no-upload` Optional argument. Runs the webscraper as normal but does not upload the data to the database.
   - `--headful` Optional argument for debugging. Runs the browser in headful mode, meaning that you can see the browser. Without this flag, the browser isn't visible. [Reference](https://developer.chrome.com/docs/chromium/new-headless).
+  - `--local-api` Optional argument. Must be running the [Energy Dashboard](https://github.com/OSU-Sustainability-Office/energy-dashboard) backend locally, and the scraper will use the localhost API instead of the production API.
 
 ### Debugging
 

--- a/ennex-os/README.md
+++ b/ennex-os/README.md
@@ -2,8 +2,9 @@
 
 Retrieves some solar panel data from OSU Operations. Email alerts integrated for failed upload.
 
-- `node readEnnex.js --no-upload`
+- `node readEnnex.js --no-upload --headful`
   - `--no-upload` Optional argument. Runs the webscraper as normal but does not upload the data to the database.
+  - `--headful` Optional argument for debugging. Runs the browser in headful mode, meaning that you can see the browser. Without this flag, the browser isn't visible. [Reference](https://developer.chrome.com/docs/chromium/new-headless).
 
 ### Debugging
 

--- a/ennex-os/readEnnex.js
+++ b/ennex-os/readEnnex.js
@@ -4,7 +4,9 @@
 
 const puppeteer = require("puppeteer");
 require("dotenv").config();
-
+const DASHBOARD_API = process.argv.includes("--local-api")
+  ? process.env.LOCAL_API
+  : process.env.DASHBOARD_API;
 const TIMEOUT_BUFFER = 600000; // lower to 25000 for debug
 const axios = require("axios");
 const meterlist = require("./meterlist.json");
@@ -332,7 +334,7 @@ const meterlist = require("./meterlist.json");
     if (!process.argv.includes("--no-upload")) {
       await axios({
         method: "post",
-        url: `${process.env.DASHBOARD_API}/upload`,
+        url: `${DASHBOARD_API}/upload`,
         data: {
           id: solarmeter,
           body: final_PV_tableData[i],

--- a/ennex-os/readEnnex.js
+++ b/ennex-os/readEnnex.js
@@ -14,7 +14,9 @@ const meterlist = require("./meterlist.json");
 
   // Launch the browser
   browser = await puppeteer.launch({
-    headless: "new", // set to false (no quotes) for debug | reference: https://developer.chrome.com/articles/new-headless/
+    // DEBUG: use --headful flag (node readEnnex.js --headful), browser will be visible
+    // reference: https://developer.chrome.com/articles/new-headless/
+    headless: process.argv.includes("--headful") ? false : "new",
     args: ["--no-sandbox"],
     // executablePath: 'google-chrome-stable'
   });

--- a/ennex-os/readEnnex.js
+++ b/ennex-os/readEnnex.js
@@ -7,7 +7,7 @@ require("dotenv").config();
 const DASHBOARD_API = process.argv.includes("--local-api")
   ? process.env.LOCAL_API
   : process.env.DASHBOARD_API;
-const TIMEOUT_BUFFER = 600000; // lower to 25000 for debug
+const TIMEOUT_BUFFER = 600000; //DEBUG: lower to 25000 for faster testing
 const axios = require("axios");
 const meterlist = require("./meterlist.json");
 


### PR DESCRIPTION
Closes #73.

New Flags
---
- `--headful`
  - Runs the Puppeteer browser in [headful](https://developer.chrome.com/docs/chromium/new-headless) mode, meaning you can see the browser UI. 
- `--local-api`
  - Runs all API requests through a locally hosted [Energy Dashboard](https://github.com/OSU-Sustainability-Office/energy-dashboard). 

Debug Syntax
---
Enforced a consistent debug syntax: `DEBUG: {debug notes here}`. Only `Check-acq` uses the `--debug-logs` right now, but we can work on adding debug logs to the other scrapers as we debug in the future and see what info is helpful to log out. 
