### PR TITLE
Change Pacific Power Meters Timezone for time_seconds

### DIFF
--- a/PacificPower/package-lock.json
+++ b/PacificPower/package-lock.json
@@ -152,44 +152,75 @@
       "integrity": "sha512-OnAYlL5b7LEkALw87fUVafQw5rVR9RjwGd4KUwNQ6DrrNmaVaUCgLipfVlzrPQ4tWOR9P0IXGNOx50jYCCdSJg=="
     },
     "node_modules/bare-events": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.0.tgz",
-      "integrity": "sha512-/E8dDe9dsbLyh2qrZ64PEPadOQ0F4gbl1sUJOrmph7xOiIxfY8vwab/4bFLh4Y88/Hk/ujKcrQKc+ps0mv873A==",
+      "version": "2.5.4",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.5.4.tgz",
+      "integrity": "sha512-+gFfDkR8pj4/TrWCGUGWmJIkBwuxPS5F+a5yWjOHQt2hHvNZd5YLzadjmDUtFmMM4y429bnKLa8bYBMHcYdnQA==",
+      "license": "Apache-2.0",
       "optional": true
     },
     "node_modules/bare-fs": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-2.3.5.tgz",
-      "integrity": "sha512-SlE9eTxifPDJrT6YgemQ1WGFleevzwY+XAP1Xqgl56HtcrisC2CHCZ2tq6dBpcH2TnNxwUEUGhweo+lrQtYuiw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.1.2.tgz",
+      "integrity": "sha512-8wSeOia5B7LwD4+h465y73KOdj5QHsbbuoUfPBi+pXgFJIPuG7SsiOdJuijWMyfid49eD+WivpfY7KT8gbAzBA==",
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "bare-events": "^2.0.0",
-        "bare-path": "^2.0.0",
-        "bare-stream": "^2.0.0"
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
       }
     },
     "node_modules/bare-os": {
-      "version": "2.4.4",
-      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-2.4.4.tgz",
-      "integrity": "sha512-z3UiI2yi1mK0sXeRdc4O1Kk8aOa/e+FNWZcTiPB/dfTWyLypuE99LibgRaQki914Jq//yAWylcAt+mknKdixRQ==",
-      "optional": true
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.1.tgz",
+      "integrity": "sha512-uaIjxokhFidJP+bmmvKSgiMzj2sV5GPHaZVAIktcxcpCyBFFWO+YlikVAdhmUo2vYFvFhOXIAlldqV29L8126g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "bare": ">=1.14.0"
+      }
     },
     "node_modules/bare-path": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-2.1.3.tgz",
-      "integrity": "sha512-lh/eITfU8hrj9Ru5quUp0Io1kJWIk1bTjzo7JH1P5dWmQ2EL4hFUlfI8FonAhSlgIfhn63p84CDY/x+PisgcXA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "bare-os": "^2.1.0"
+        "bare-os": "^3.0.1"
       }
     },
     "node_modules/bare-stream": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.3.2.tgz",
-      "integrity": "sha512-EFZHSIBkDgSHIwj2l2QZfP4U5OcD4xFAOwhSb/vlr9PIqyGJGvB/nfClJbcnh3EY4jtPE4zsb5ztae96bVF79A==",
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.6.5.tgz",
+      "integrity": "sha512-jSmxKJNJmHySi6hC42zlZnq00rga4jjxcgNZjY9N5WlOe/iOoGRtdwGsHzQv2RlH2KOYMwGUXhf2zXd32BA9RA==",
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
-        "streamx": "^2.20.0"
+        "streamx": "^2.21.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
       }
     },
     "node_modules/base64-js": {
@@ -952,11 +983,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/queue-tick": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/queue-tick/-/queue-tick-1.0.1.tgz",
-      "integrity": "sha512-kJt5qhMxoszgU/62PLP1CJytzd2NKetjSRnyuj31fDd3Rlcz3fzlFdFLD1SItunPwyqEOkca6GbV612BWfaBag=="
-    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -1034,12 +1060,12 @@
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA=="
     },
     "node_modules/streamx": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.20.1.tgz",
-      "integrity": "sha512-uTa0mU6WUC65iUvzKH4X9hEdvSW7rbPxPtwfWiLMSj3qTdQbAiUboZTxauKfpFuGIGa1C2BYijZ7wgdUXICJhA==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.22.0.tgz",
+      "integrity": "sha512-sLh1evHOzBy/iWRiR6d1zRcLao4gGZr3C1kzNz4fopCOKJb6xD9ub8Mpi9Mr1R6id5o43S+d93fI48UC5uM9aw==",
+      "license": "MIT",
       "dependencies": {
         "fast-fifo": "^1.3.2",
-        "queue-tick": "^1.0.1",
         "text-decoder": "^1.1.0"
       },
       "optionalDependencies": {
@@ -1071,16 +1097,17 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.6.tgz",
-      "integrity": "sha512-iokBDQQkUyeXhgPYaZxmczGPhnhXZ0CmrqI+MOb/WFGS9DW5wnfrLgtjUJBvz50vQ3qfRwJ62QVoCFu8mPVu5w==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.0.8.tgz",
+      "integrity": "sha512-ZoROL70jptorGAlgAYiLoBLItEKw/fUxg9BSYK/dF/GAGYFJOJJJMvjPAKDJraCXFwadD456FCuvLWgfhMsPwg==",
+      "license": "MIT",
       "dependencies": {
         "pump": "^3.0.0",
         "tar-stream": "^3.1.5"
       },
       "optionalDependencies": {
-        "bare-fs": "^2.1.1",
-        "bare-path": "^2.1.0"
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
       }
     },
     "node_modules/tar-stream": {

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -606,23 +606,29 @@ async function getRowText(monthly_top_const, row_days) {
   return monthly_top_text;
 }
 
+/* Returns the date for today minus the number of days specified in two formats:
+  * {
+  *   actualDate: '2021-10-07',
+  *   ACTUAL_DATE_UNIX: '1633622399',
+  * }
+*/
 function getActualDate(num_days) {
   // reference (get time in any timezone and string format): https://momentjs.com/timezone/docs/
-  // yesterday's date in PST timezone, YYYY-MM-DD format
-  let actualDate = moment
-    .tz(
-      new Date(new Date().getTime() - num_days * 24 * 60 * 60 * 1000),
-      "America/Los_Angeles",
-    )
+  // get the actual date
+  const actualDate = moment
+    .tz(Date.now() - num_days * 24 * 60 * 60 * 1000, "America/Los_Angeles")
     .format("YYYY-MM-DD");
-  const actualDateObj = new Date(actualDate);
+    
+  // convert to unix time
+  const end_of_day_time = actualDate + "T23:59:59"; // always set to 11:59:59 PM (PST)
+  const UNIX_TIME = moment
+    .tz(end_of_day_time, "America/Los_Angeles")
+    .unix(); // END_TIME in seconds (PST)
 
-  // unix time calc
-  actualDateObj.setUTCHours(23, 59, 59, 0);
-  const ACTUAL_DATE_UNIX = Math.floor(
-    actualDateObj.valueOf() / 1000,
-  ).toString();
-  return { actualDate, ACTUAL_DATE_UNIX };
+  return { 
+    actualDate: actualDate, 
+    ACTUAL_DATE_UNIX: UNIX_TIME 
+  };
 }
 
 /**
@@ -643,12 +649,7 @@ function formatDateAndTime(date) {
   });
   const [MONTH, DAY, YEAR] = formattedDate.split("/");
   const DATE_TIME = `${YEAR}-${MONTH}-${DAY}T23:59:59`; // always set to 11:59:59 PM (PST)
-  const UNIX_TIME =
-    new Date(
-      new Date(DATE_TIME).toLocaleString("en-US", {
-        timeZone: "America/Los_Angeles",
-      }),
-    ).getTime() / 1000; // END_TIME in seconds (PST)
+  const UNIX_TIME = moment.tz(`${DATE_TIME}`, "America/Los_Angeles").unix(); // END_TIME in seconds (PST)
 
   return {
     END_TIME: DATE_TIME,

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -633,7 +633,7 @@ function getActualDate(num_days) {
 
 /**
  * Parameters:
- * - date: Date object (e.g. new Date() or new Date("2021-10-07"))
+ * - date: Date string (e.g. "2021-10-07")
  * Returns an object of date in two formats:
  * {
  *    END_TIME: '2021-10-07T23:59:59',
@@ -641,13 +641,7 @@ function getActualDate(num_days) {
  * }
  */
 function formatDateAndTime(date) {
-  // Convert date object to string
-  const formattedDate = date.toLocaleDateString("en-US", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  });
-  const [MONTH, DAY, YEAR] = formattedDate.split("/");
+  const [YEAR, MONTH, DAY] = date.split("-");
   const DATE_TIME = `${YEAR}-${MONTH}-${DAY}T23:59:59`; // always set to 11:59:59 PM (PST)
   const UNIX_TIME = moment.tz(`${DATE_TIME}`, "America/Los_Angeles").unix(); // END_TIME in seconds (PST)
 
@@ -665,11 +659,8 @@ async function getRowData(monthly_top_text, positionUsage, positionEst) {
   // get the date for the data
   let positionPeriod = "Period";
   let positionAve = "Average";
-  let date = monthly_top_text.split(positionPeriod)[1].split(positionAve)[0];
-
-  // get today's date
-  const dateObj = new Date(date);
-  const {END_TIME, END_TIME_SECONDS} = formatDateAndTime(dateObj)
+  const date = monthly_top_text.split(positionPeriod)[1].split(positionAve)[0];
+  const {END_TIME, END_TIME_SECONDS} = formatDateAndTime(date)
 
   return { usage_kwh, date, END_TIME, END_TIME_SECONDS };
 }

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -625,6 +625,37 @@ function getActualDate(num_days) {
   return { actualDate, ACTUAL_DATE_UNIX };
 }
 
+/**
+ * Parameters:
+ * - date: Date object (e.g. new Date() or new Date("2021-10-07"))
+ * Returns an object of date in two formats:
+ * {
+ *    END_TIME: '2021-10-07T23:59:59',
+ *    END_TIME_SECONDS: '1633622399',
+ * }
+ */
+function formatDateAndTime(date) {
+  // Convert date object to string
+  const formattedDate = date.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  const [MONTH, DAY, YEAR] = formattedDate.split("/");
+  const DATE_TIME = `${YEAR}-${MONTH}-${DAY}T23:59:59`; // always set to 11:59:59 PM (PST)
+  const UNIX_TIME =
+    new Date(
+      new Date(DATE_TIME).toLocaleString("en-US", {
+        timeZone: "America/Los_Angeles",
+      }),
+    ).getTime() / 1000; // END_TIME in seconds (PST)
+
+  return {
+    END_TIME: DATE_TIME,
+    END_TIME_SECONDS: UNIX_TIME,
+  };
+}
+
 async function getRowData(monthly_top_text, positionUsage, positionEst) {
   let usage_kwh = parseFloat(
     monthly_top_text.split(positionUsage)[1].split(positionEst)[0],
@@ -635,7 +666,9 @@ async function getRowData(monthly_top_text, positionUsage, positionEst) {
   let positionAve = "Average";
   let date = monthly_top_text.split(positionPeriod)[1].split(positionAve)[0];
 
+  // get today's date
   const dateObj = new Date(date);
+  const formattedDate = formatDateAndTime(dateObj)
   const END_TIME = `${date}T23:59:59`;
 
   // unix time calc

--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -668,12 +668,8 @@ async function getRowData(monthly_top_text, positionUsage, positionEst) {
 
   // get today's date
   const dateObj = new Date(date);
-  const formattedDate = formatDateAndTime(dateObj)
-  const END_TIME = `${date}T23:59:59`;
+  const {END_TIME, END_TIME_SECONDS} = formatDateAndTime(dateObj)
 
-  // unix time calc
-  dateObj.setUTCHours(23, 59, 59, 0);
-  const END_TIME_SECONDS = Math.floor(dateObj.valueOf() / 1000).toString();
   return { usage_kwh, date, END_TIME, END_TIME_SECONDS };
 }
 


### PR DESCRIPTION
The Pacific Power meter data is currently uploading the time_seconds field into the database incorrectly. It is always set to 11:59 PM UTC, whereas it should be 11:59 PM PST (which corresponds to 6:59 or 7:59 AM UTC depending on daylight savings). This PR fixes that discrepancy, ensuring the data is correctly handled by the energy dashboard when displayed.

NOTE: I already pushed this to AWS to ensure that incoming data is correct