### PR TITLE
Add Automated Job to Fetch OpenStreet Map Data for Energy Dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ All console commands below should be run from the directory unless stated otherw
   - `node check-acq.js`
 - **PacificPower** (Deployed): Retrieves energy data for several meters from Pacific Power website. Emails alerts integrated for new meters and failed uploads.
   - `node readPP.js`
+- **refresh-osm** (Deployed): Retrieves building outline data in GeoJSON format from the Overpass API (OpenStreetMap) and stores it in the buildings table of the database. Used primarily for rendering building outlines on the map.
 
 ## Deprecated
 

--- a/refresh-osm/README.md
+++ b/refresh-osm/README.md
@@ -2,7 +2,7 @@
 
 Retrieves building outline data in GeoJSON format from the Overpass API (OpenStreetMap) and stores it in the buildings table of the database. Used primarily for rendering building outlines on the map. Runs bi-weekly.
 
-- `node refresh-osm.js --no-upload --local-api`
+- `node osm.js --no-upload --local-api`
   - `--no-upload` Optional argument. Runs the webscraper as normal but does not upload any GeoJSON data to the database.
   - `--local-api` Optional argument. Must be running the [Energy Dashboard](https://github.com/OSU-Sustainability-Office/energy-dashboard) backend locally, and the scraper will use the localhost API instead of the production API.
 

--- a/refresh-osm/README.md
+++ b/refresh-osm/README.md
@@ -1,0 +1,11 @@
+## refresh-osm
+
+Retrieves building outline data in GeoJSON format from the Overpass API (OpenStreetMap) and stores it in the buildings table of the database. Used primarily for rendering building outlines on the map. Runs bi-weekly.
+
+- `node refresh-osm.js --no-upload --local-api`
+  - `--no-upload` Optional argument. Runs the webscraper as normal but does not upload any GeoJSON data to the database.
+  - `--local-api` Optional argument. Must be running the [Energy Dashboard](https://github.com/OSU-Sustainability-Office/energy-dashboard) backend locally, and the scraper will use the localhost API instead of the production API.
+
+### Formatting
+
+- `npm run format`

--- a/refresh-osm/dockerfile
+++ b/refresh-osm/dockerfile
@@ -1,11 +1,11 @@
 # syntax=docker/dockerfile:1
-FROM node:19-bullseye-slim
+FROM node:22-bullseye-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
     libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libgtk-3-0 \
     libasound2 libxshmfence1 libx11-xcb1
-WORKDIR /ennex_webscraper
+WORKDIR /refresh-osm
 COPY package.json package-lock.json ./
 RUN npm install --production
 COPY . .

--- a/refresh-osm/dockerfile
+++ b/refresh-osm/dockerfile
@@ -1,0 +1,12 @@
+# syntax=docker/dockerfile:1
+FROM node:19-bullseye-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libglib2.0-0 libnss3 libatk1.0-0 libatk-bridge2.0-0 libcups2 libdrm2 \
+    libxkbcommon0 libxcomposite1 libxdamage1 libxrandr2 libgbm1 libgtk-3-0 \
+    libasound2 libxshmfence1 libx11-xcb1
+WORKDIR /ennex_webscraper
+COPY package.json package-lock.json ./
+RUN npm install --production
+COPY . .
+CMD ["node", "readEnnex.js"]

--- a/refresh-osm/osm.js
+++ b/refresh-osm/osm.js
@@ -1,16 +1,15 @@
 // Imports
-const axios = require("axios");
 require('dotenv').config()
-const DOMParser = require('xmldom').DOMParser;
+const axios = require("axios");
+const DOMParser = require('@xmldom/xmldom').DOMParser;
 const osmtogeojson = require('osmtogeojson');
 
 // Constants
 const DASHBOARD_API = process.argv.includes("--local-api")
   ? process.env.LOCAL_API
   : process.env.DASHBOARD_API;
-
-// Fetch all building data from database
-async function fetchBuildingData() {
+ 
+async function fetchAllBuildingData() {
     const buildingData = await axios({
     method: "get",
     url: `${DASHBOARD_API}/allbuildings`,
@@ -18,61 +17,77 @@ async function fetchBuildingData() {
     return buildingData.data;
 }
 
-// Extract all building ID and Way IDs from building data
-async function extractBuildingIds() {
-    const buildingData = await fetchBuildingData();
-    const buildingInfo = buildingData
+async function mapWayIdtoBuildingId() {
+    const buildingData = await fetchAllBuildingData();
+    const mapIdToBuildingId = new Map();
+
+    // Create a map of wayId to building
+    buildingData
         .filter(building => building.mapId) // Exclude buildings with blank wayId
-        .map(building => ({
-            buildingId: parseInt(building.id),
-            wayId: building.mapId
-        }));
-    return buildingInfo;
+        .forEach(building => {
+            const wayId = building.mapId;
+            const buildingId = parseInt(building.id);
+            mapIdToBuildingId.set(wayId, buildingId);
+        });
+
+    return mapIdToBuildingId;
 }
 
-// Get GeoJSON data from OSM
+// Get GeoJSON data from OSM using Overpass API
 async function fetchGeoJSONData(Ids) {
     const base = 'https://maps.mail.ru/osm/tools/overpass/api';
     const route = `interpreter?data=[out:xml];way(id:${Ids});(._;>;);out;`
     const osmXML = await axios({
         method: "get",
         url: `${base}/${route}`,
+        headers: {
+             Accept: 'text/xml'
+        },
     });
 
     // Parse the OSM XML response
-    const doc = new DOMParser().parseFromString(osmXML);
-    const geojson = osmtogeojson(doc);
-
+    const xmlDoc = new DOMParser().parseFromString(osmXML.data, 'text/xml');
+    const geojson = osmtogeojson(xmlDoc);
     return geojson;
 }
 
 // Update GeoJSON data in MySQL
-async function updateGeoJSONData(buildingId, geojson) {
+async function updateGeoJSONData(buildings) {
     const response = await axios({
         method: "put",
         url: `${DASHBOARD_API}/buildinggeojson`,
         data: {
-            'id': buildingId,
-            'geoJSON': geojson
+            buildings: buildings
         }
     });
-    return response.data;
+    return response;
+}
+
+// Some buildings are Polygons by definition, but are returned as LineStrings
+// by OSM. This function corrects the geometry type if necessary.
+async function correctGeometry(feature) {
+    // Convert LineString to Polygon if it is a closed shape
+    if (feature.geometry.type === 'LineString') {
+        const coords = feature.geometry.coordinates
+        if (coords[0][0] === coords[coords.length - 1][0] && coords[0][1] === coords[coords.length - 1][1]) {
+            feature.geometry.type = 'Polygon'
+            feature.geometry.coordinates = [coords]
+        }
+    }
 }
 
 async function main() {
-    // Get the ID and Way ID from MySQL
-    const buildingInfo = await extractBuildingIds();
-
-    // Create a map of wayId to buildingId
-    const mapIdToBuildingId = new Map();
-    const mapIds = buildingInfo.map(b => {
-      mapIdToBuildingId.set(b.wayId, b.buildingId);
-      return b.wayId;
-    });
+    // Build a map of wayId to buildingId
+    const mapIdToBuildingId = await mapWayIdtoBuildingId();
 
     // Get OSM data for all buildings
-    const wayIds = mapIds.join(',');
+    const wayIds = mapIdToBuildingId.join(',');
     const geojson = await fetchGeoJSONData(wayIds);
+
+    // Correct the geometry type if necessary
+    for (const feature of geojson.features) {
+        await correctGeometry(feature);
+    }
 
     // Build a map of buildingId to GeoJSON feature
     const buildingGeoMap = new Map();
@@ -80,16 +95,20 @@ async function main() {
       const osmId = feature.id.split('/')[1]; // e.g. "way/123456" → "123456"
       const buildingId = mapIdToBuildingId.get(osmId);
       if (buildingId) {
-        buildingGeoMap.set(buildingId, feature);
+        const buildingIdInt = parseInt(buildingId);
+        buildingGeoMap.set(buildingIdInt, feature);
       }
     }
 
-    // Update first building for testing
-    const firstBuildingId = Array.from(buildingGeoMap.keys())[0];
-    const firstGeoJSON = buildingGeoMap.get(firstBuildingId);
-    const firstGeoJSONString = JSON.stringify(firstGeoJSON);
-    const firstUpdateResponse = await updateGeoJSONData(firstBuildingId, firstGeoJSONString);
-    console.log(firstUpdateResponse);
+    // Convert the map to an array of objects
+    const buildingGeoArray = Array.from(buildingGeoMap, ([id, geoJSON]) => ({
+        buildingId: id,
+        buildingGeoJSON: geoJSON
+    }));
+
+    // Update the database with the new GeoJSON data
+    const updateResponse = await updateGeoJSONData(buildingGeoArray);
+    console.log(updateResponse.data);
 }
 
 // Execute the main function

--- a/refresh-osm/osm.js
+++ b/refresh-osm/osm.js
@@ -10,63 +10,67 @@ const DASHBOARD_API = process.argv.includes("--local-api")
   : process.env.DASHBOARD_API;
  
 async function fetchAllBuildingData() {
-    const buildingData = await axios({
-    method: "get",
-    url: `${DASHBOARD_API}/allbuildings`,
-    })
-    return buildingData.data;
-}
-
-async function mapWayIdtoBuildingId() {
-    const buildingData = await fetchAllBuildingData();
-    const mapIdToBuildingId = new Map();
-
-    // Create a map of wayId to building
-    buildingData
-        .filter(building => building.mapId) // Exclude buildings with blank wayId
-        .forEach(building => {
-            const wayId = building.mapId;
-            const buildingId = parseInt(building.id);
-            mapIdToBuildingId.set(wayId, buildingId);
+    try {
+        const response = await axios({
+            method: "get",
+            url: `${DASHBOARD_API}/allbuildings`,
         });
-
-    return mapIdToBuildingId;
+        return response.data;
+    } catch (error) {
+        console.error("Error fetching building data:", error);
+        throw error;
+    }
 }
 
-// Get GeoJSON data from OSM using Overpass API
 async function fetchGeoJSONData(Ids) {
-    const base = 'https://maps.mail.ru/osm/tools/overpass/api';
-    const route = `interpreter?data=[out:xml];way(id:${Ids});(._;>;);out;`
-    const osmXML = await axios({
-        method: "get",
-        url: `${base}/${route}`,
-        headers: {
-             Accept: 'text/xml'
-        },
-    });
-
-    // Parse the OSM XML response
-    const xmlDoc = new DOMParser().parseFromString(osmXML.data, 'text/xml');
-    const geojson = osmtogeojson(xmlDoc);
-    return geojson;
+    try {
+        const base = 'https://maps.mail.ru/osm/tools/overpass/api';
+        const route = `interpreter?data=[out:xml];way(id:${Ids});(._;>;);out;`
+        const osmXML = await axios({
+            method: "get",
+            url: `${base}/${route}`,
+            headers: {
+                 Accept: 'text/xml'
+            },
+        });
+        
+        // Parse the OSM XML response
+        const xmlDoc = new DOMParser().parseFromString(osmXML.data, 'text/xml');
+        const geojson = osmtogeojson(xmlDoc);
+        return geojson;
+    } catch (error) {
+        console.error("Error fetching GeoJSON data:", error);
+        throw error;
+    }
 }
 
-// Update GeoJSON data in MySQL
-async function updateGeoJSONData(buildings) {
-    const response = await axios({
-        method: "put",
-        url: `${DASHBOARD_API}/buildinggeojson`,
-        data: {
-            buildings: buildings
+/* This function creates a map of building objects with the following properties:
+    * Key: The OSM way ID of the building
+    * Value: An object containing the following properties:
+        * buildingId: The ID of the building
+        * buildingName: The name of the building
+        * buildingGroup: The group of the building
+*/
+async function createbuildingMap() {
+    const buildingData = await fetchAllBuildingData();
+    const buildingMap = new Map();
+
+    for (const building of buildingData) {
+        if (!building.mapId) continue; // Skip buildings with blank wayId
+        
+        buildingMap.set(building.mapId, {
+            buildingId: parseInt(building.id),
+            buildingName: building.name,
+            buildingGroup: building.group,
+          });
         }
-    });
-    return response;
+
+    return buildingMap;
 }
 
 // Some buildings are Polygons by definition, but are returned as LineStrings
 // by OSM. This function corrects the geometry type if necessary.
-async function correctGeometry(feature) {
-    // Convert LineString to Polygon if it is a closed shape
+function correctGeometry(feature) {
     if (feature.geometry.type === 'LineString') {
         const coords = feature.geometry.coordinates
         if (coords[0][0] === coords[coords.length - 1][0] && coords[0][1] === coords[coords.length - 1][1]) {
@@ -76,39 +80,81 @@ async function correctGeometry(feature) {
     }
 }
 
+/* The energy dashboard uses these properties to identify and setup
+    * buildings on the map. This function sets the properties of each feature
+    * in the GeoJSON data to match the building objects.
+*/
+function setBuildingProperties(feature, building) {
+    feature.properties = {
+        id: building.buildingId,
+        group: building.buildingGroup,
+        name: building.buildingName,
+    };
+}
+
+/*
+    * This function normalizes the GeoJSON data to ensure the data is ready to
+    * be used in the Energy Dashboard.
+*/
+function normalizeData(buildingMap, geojson) { 
+    const normalizedBuildingArray = [];
+
+    for (const feature of geojson.features) {
+        const wayId = String(feature.id.split('/')[1]);
+        const building = buildingMap.get(wayId);
+      
+        if (building) {
+            // Set the properties of the feature
+            setBuildingProperties(feature, building);
+
+            // Set the geometry type to Polygon if it is a closed shape
+            correctGeometry(feature);
+
+            // Add the feature to the normalized building array
+            normalizedBuildingArray.push({
+                buildingId: building.buildingId,
+                buildingGeoJSON: feature
+            });
+        }
+    }
+
+    return normalizedBuildingArray;
+}
+
+// This function updates the GeoJSON data in the database
+// with the new building properties using the Energy Dashboard API.
+async function updateGeoJSONData(buildings) {
+    try {
+        const response = await axios({
+            method: "put",
+            url: `${DASHBOARD_API}/buildinggeojson`,
+            data: {
+                buildings: buildings
+            }
+        });
+        return response;
+    } catch (error) {
+        console.error("Error updating GeoJSON data:", error);
+        throw error;
+    }
+}
+
 async function main() {
-    // Build a map of wayId to buildingId
-    const mapIdToBuildingId = await mapWayIdtoBuildingId();
+    // Build a map of wayId to building properties
+    const buildingMap = await createbuildingMap();
 
     // Get OSM data for all buildings
-    const wayIds = mapIdToBuildingId.join(',');
+    const wayIds = Array.from(buildingMap.keys()).join(',');
     const geojson = await fetchGeoJSONData(wayIds);
 
-    // Correct the geometry type if necessary
-    for (const feature of geojson.features) {
-        await correctGeometry(feature);
-    }
-
-    // Build a map of buildingId to GeoJSON feature
-    const buildingGeoMap = new Map();
-    for (const feature of geojson.features) {
-      const osmId = feature.id.split('/')[1]; // e.g. "way/123456" → "123456"
-      const buildingId = mapIdToBuildingId.get(osmId);
-      if (buildingId) {
-        const buildingIdInt = parseInt(buildingId);
-        buildingGeoMap.set(buildingIdInt, feature);
-      }
-    }
-
-    // Convert the map to an array of objects
-    const buildingGeoArray = Array.from(buildingGeoMap, ([id, geoJSON]) => ({
-        buildingId: id,
-        buildingGeoJSON: geoJSON
-    }));
+    // Preapre the GeoJSON data
+    const normalizedBuildingArray = normalizeData(buildingMap, geojson);
 
     // Update the database with the new GeoJSON data
-    const updateResponse = await updateGeoJSONData(buildingGeoArray);
-    console.log(updateResponse.data);
+    if (!process.argv.includes("--no-upload")) {
+        const response = await updateGeoJSONData(normalizedBuildingArray);
+        console.log(response.data);
+      }
 }
 
 // Execute the main function

--- a/refresh-osm/osm.js
+++ b/refresh-osm/osm.js
@@ -113,6 +113,11 @@ function normalizeData(buildingMap, geojson) {
   const normalizedBuildingArray = [];
 
   for (const feature of geojson.features) {
+    const wayOrNode = String(feature.id.split("/")[0]);
+    if (wayOrNode !== "way") {
+      continue; // Ignore node features
+    }
+
     const wayId = String(feature.id.split("/")[1]);
     const building = buildingMap.get(wayId);
 

--- a/refresh-osm/osm.js
+++ b/refresh-osm/osm.js
@@ -157,7 +157,7 @@ async function main() {
     const wayIds = Array.from(buildingMap.keys()).join(',');
     const geojson = await fetchGeoJSONData(wayIds);
 
-    // Preapre the GeoJSON data
+    // Prepare the GeoJSON data
     const normalizedBuildingArray = normalizeData(buildingMap, geojson);
 
     // Update the database with the new GeoJSON data

--- a/refresh-osm/osm.js
+++ b/refresh-osm/osm.js
@@ -1,0 +1,96 @@
+// Imports
+const axios = require("axios");
+require('dotenv').config()
+const DOMParser = require('xmldom').DOMParser;
+const osmtogeojson = require('osmtogeojson');
+
+// Constants
+const DASHBOARD_API = process.argv.includes("--local-api")
+  ? process.env.LOCAL_API
+  : process.env.DASHBOARD_API;
+
+// Fetch all building data from database
+async function fetchBuildingData() {
+    const buildingData = await axios({
+    method: "get",
+    url: `${DASHBOARD_API}/allbuildings`,
+    })
+    return buildingData.data;
+}
+
+// Extract all building ID and Way IDs from building data
+async function extractBuildingIds() {
+    const buildingData = await fetchBuildingData();
+    const buildingInfo = buildingData
+        .filter(building => building.mapId) // Exclude buildings with blank wayId
+        .map(building => ({
+            buildingId: parseInt(building.id),
+            wayId: building.mapId
+        }));
+    return buildingInfo;
+}
+
+// Get GeoJSON data from OSM
+async function fetchGeoJSONData(Ids) {
+    const base = 'https://maps.mail.ru/osm/tools/overpass/api';
+    const route = `interpreter?data=[out:xml];way(id:${Ids});(._;>;);out;`
+    const osmXML = await axios({
+        method: "get",
+        url: `${base}/${route}`,
+    });
+
+    // Parse the OSM XML response
+    const doc = new DOMParser().parseFromString(osmXML);
+    const geojson = osmtogeojson(doc);
+
+    return geojson;
+}
+
+// Update GeoJSON data in MySQL
+async function updateGeoJSONData(buildingId, geojson) {
+    const response = await axios({
+        method: "put",
+        url: `${DASHBOARD_API}/buildinggeojson`,
+        data: {
+            'id': buildingId,
+            'geoJSON': geojson
+        }
+    });
+    return response.data;
+}
+
+async function main() {
+    // Get the ID and Way ID from MySQL
+    const buildingInfo = await extractBuildingIds();
+
+    // Create a map of wayId to buildingId
+    const mapIdToBuildingId = new Map();
+    const mapIds = buildingInfo.map(b => {
+      mapIdToBuildingId.set(b.wayId, b.buildingId);
+      return b.wayId;
+    });
+
+    // Get OSM data for all buildings
+    const wayIds = mapIds.join(',');
+    const geojson = await fetchGeoJSONData(wayIds);
+
+    // Build a map of buildingId to GeoJSON feature
+    const buildingGeoMap = new Map();
+    for (const feature of geojson.features) {
+      const osmId = feature.id.split('/')[1]; // e.g. "way/123456" → "123456"
+      const buildingId = mapIdToBuildingId.get(osmId);
+      if (buildingId) {
+        buildingGeoMap.set(buildingId, feature);
+      }
+    }
+
+    // Update first building for testing
+    const firstBuildingId = Array.from(buildingGeoMap.keys())[0];
+    const firstGeoJSON = buildingGeoMap.get(firstBuildingId);
+    const firstGeoJSONString = JSON.stringify(firstGeoJSON);
+    const firstUpdateResponse = await updateGeoJSONData(firstBuildingId, firstGeoJSONString);
+    console.log(firstUpdateResponse);
+}
+
+// Execute the main function
+main()

--- a/refresh-osm/osm.js
+++ b/refresh-osm/osm.js
@@ -125,9 +125,16 @@ function normalizeData(buildingMap, geojson) {
                 buildingId: building.buildingId,
                 buildingGeoJSON: feature
             });
+
+            // Remove building from map to indicate it has been processed
+            buildingMap.delete(wayId);
         }
     }
 
+    // Trigger an error if a building has not been found in the GeoJSON data (usually indicates invalid wayId)
+    if (buildingMap.size > 0) {
+        console.error("The following buildings were not found in the GeoJSON data:", Array.from(buildingMap.values()));
+    }
     return normalizedBuildingArray;
 }
 

--- a/refresh-osm/osm.js
+++ b/refresh-osm/osm.js
@@ -1,3 +1,13 @@
+/* This script fetches GeoJSON data from the Overpass API and uploads it via the Energy Dashboard API.
+    * It was designed to reduce overhead and improve performance by elimanating the need to fetch the data
+    * from the client side. It is meant be run as a cron job to keep the GeoJSON data up to date.
+    * The script does the following:
+        1. Fetches all building data from the Energy Dashboard API
+        2. Fetches GeoJSON data from the Overpass API using the building IDs
+        3. Normalizes the GeoJSON data to ensure it is ready to be used in the Energy Dashboard
+        4. Updates the GeoJSON data in the database with the new building properties using the Energy Dashboard API
+*/
+
 // Imports
 require('dotenv').config()
 const axios = require("axios");

--- a/refresh-osm/osm.js
+++ b/refresh-osm/osm.js
@@ -9,170 +9,177 @@
 */
 
 // Imports
-require('dotenv').config()
+require("dotenv").config();
 const axios = require("axios");
-const DOMParser = require('@xmldom/xmldom').DOMParser;
-const osmtogeojson = require('osmtogeojson');
+const DOMParser = require("@xmldom/xmldom").DOMParser;
+const osmtogeojson = require("osmtogeojson");
 
 // Constants
 const DASHBOARD_API = process.argv.includes("--local-api")
   ? process.env.LOCAL_API
   : process.env.DASHBOARD_API;
- 
+
 async function fetchAllBuildingData() {
-    try {
-        const response = await axios({
-            method: "get",
-            url: `${DASHBOARD_API}/allbuildings`,
-        });
-        return response.data;
-    } catch (error) {
-        console.error("Error fetching building data:", error);
-        throw error;
-    }
+  try {
+    const response = await axios({
+      method: "get",
+      url: `${DASHBOARD_API}/allbuildings`,
+    });
+    return response.data;
+  } catch (error) {
+    console.error("Error fetching building data:", error);
+    throw error;
+  }
 }
 
 async function fetchGeoJSONData(Ids) {
-    try {
-        const base = 'https://maps.mail.ru/osm/tools/overpass/api';
-        const route = `interpreter?data=[out:xml];way(id:${Ids});(._;>;);out;`
-        const osmXML = await axios({
-            method: "get",
-            url: `${base}/${route}`,
-            headers: {
-                 Accept: 'text/xml'
-            },
-        });
-        
-        // Parse the OSM XML response
-        const xmlDoc = new DOMParser().parseFromString(osmXML.data, 'text/xml');
-        const geojson = osmtogeojson(xmlDoc);
-        return geojson;
-    } catch (error) {
-        console.error("Error fetching GeoJSON data:", error);
-        throw error;
-    }
+  try {
+    const base = "https://maps.mail.ru/osm/tools/overpass/api";
+    const route = `interpreter?data=[out:xml];way(id:${Ids});(._;>;);out;`;
+    const osmXML = await axios({
+      method: "get",
+      url: `${base}/${route}`,
+      headers: {
+        Accept: "text/xml",
+      },
+    });
+
+    // Parse the OSM XML response
+    const xmlDoc = new DOMParser().parseFromString(osmXML.data, "text/xml");
+    const geojson = osmtogeojson(xmlDoc);
+    return geojson;
+  } catch (error) {
+    console.error("Error fetching GeoJSON data:", error);
+    throw error;
+  }
 }
 
 /* This function creates a map of building objects with the following properties:
-    * Key: The OSM way ID of the building
-    * Value: An object containing the following properties:
-        * buildingId: The ID of the building
-        * buildingName: The name of the building
-        * buildingGroup: The group of the building
-*/
+ * Key: The OSM way ID of the building
+ * Value: An object containing the following properties:
+ * buildingId: The ID of the building
+ * buildingName: The name of the building
+ * buildingGroup: The group of the building
+ */
 async function createbuildingMap() {
-    const buildingData = await fetchAllBuildingData();
-    const buildingMap = new Map();
+  const buildingData = await fetchAllBuildingData();
+  const buildingMap = new Map();
 
-    for (const building of buildingData) {
-        if (!building.mapId) continue; // Skip buildings with blank wayId
-        
-        buildingMap.set(building.mapId, {
-            buildingId: parseInt(building.id),
-            buildingName: building.name,
-            buildingGroup: building.group,
-          });
-        }
+  for (const building of buildingData) {
+    if (!building.mapId) continue; // Skip buildings with blank wayId
 
-    return buildingMap;
+    buildingMap.set(building.mapId, {
+      buildingId: parseInt(building.id),
+      buildingName: building.name,
+      buildingGroup: building.group,
+    });
+  }
+
+  return buildingMap;
 }
 
 // Some buildings are Polygons by definition, but are returned as LineStrings
 // by OSM. This function corrects the geometry type if necessary.
 function correctGeometry(feature) {
-    if (feature.geometry.type === 'LineString') {
-        const coords = feature.geometry.coordinates
-        if (coords[0][0] === coords[coords.length - 1][0] && coords[0][1] === coords[coords.length - 1][1]) {
-            feature.geometry.type = 'Polygon'
-            feature.geometry.coordinates = [coords]
-        }
+  if (feature.geometry.type === "LineString") {
+    const coords = feature.geometry.coordinates;
+    if (
+      coords[0][0] === coords[coords.length - 1][0] &&
+      coords[0][1] === coords[coords.length - 1][1]
+    ) {
+      feature.geometry.type = "Polygon";
+      feature.geometry.coordinates = [coords];
     }
+  }
 }
 
 /* The energy dashboard uses these properties to identify and setup
-    * buildings on the map. This function sets the properties of each feature
-    * in the GeoJSON data to match the building objects.
-*/
+ * buildings on the map. This function sets the properties of each feature
+ * in the GeoJSON data to match the building objects.
+ */
 function setBuildingProperties(feature, building) {
-    feature.properties = {
-        id: building.buildingId,
-        group: building.buildingGroup,
-        name: building.buildingName,
-    };
+  feature.properties = {
+    id: building.buildingId,
+    group: building.buildingGroup,
+    name: building.buildingName,
+  };
 }
 
 /*
-    * This function normalizes the GeoJSON data to ensure the data is ready to
-    * be used in the Energy Dashboard.
-*/
-function normalizeData(buildingMap, geojson) { 
-    const normalizedBuildingArray = [];
+ * This function normalizes the GeoJSON data to ensure the data is ready to
+ * be used in the Energy Dashboard.
+ */
+function normalizeData(buildingMap, geojson) {
+  const normalizedBuildingArray = [];
 
-    for (const feature of geojson.features) {
-        const wayId = String(feature.id.split('/')[1]);
-        const building = buildingMap.get(wayId);
-      
-        if (building) {
-            // Set the properties of the feature
-            setBuildingProperties(feature, building);
+  for (const feature of geojson.features) {
+    const wayId = String(feature.id.split("/")[1]);
+    const building = buildingMap.get(wayId);
 
-            // Set the geometry type to Polygon if it is a closed shape
-            correctGeometry(feature);
+    if (building) {
+      // Set the properties of the feature
+      setBuildingProperties(feature, building);
 
-            // Add the feature to the normalized building array
-            normalizedBuildingArray.push({
-                buildingId: building.buildingId,
-                buildingGeoJSON: feature
-            });
+      // Set the geometry type to Polygon if it is a closed shape
+      correctGeometry(feature);
 
-            // Remove building from map to indicate it has been processed
-            buildingMap.delete(wayId);
-        }
+      // Add the feature to the normalized building array
+      normalizedBuildingArray.push({
+        buildingId: building.buildingId,
+        buildingGeoJSON: feature,
+      });
+
+      // Remove building from map to indicate it has been processed
+      buildingMap.delete(wayId);
     }
+  }
 
-    // Trigger an error if a building has not been found in the GeoJSON data (usually indicates invalid wayId)
-    if (buildingMap.size > 0) {
-        console.error("The following buildings were not found in the GeoJSON data:", Array.from(buildingMap.values()));
-    }
-    return normalizedBuildingArray;
+  // Trigger an error if a building has not been found in the GeoJSON data (usually indicates invalid wayId)
+  if (buildingMap.size > 0) {
+    console.error(
+      "The following buildings were not found in the GeoJSON data:",
+      Array.from(buildingMap.values()),
+    );
+  }
+  return normalizedBuildingArray;
 }
 
 // This function updates the GeoJSON data in the database
 // with the new building properties using the Energy Dashboard API.
 async function updateGeoJSONData(buildings) {
-    try {
-        const response = await axios({
-            method: "put",
-            url: `${DASHBOARD_API}/buildinggeojson`,
-            data: {
-                buildings: buildings
-            }
-        });
-        return response;
-    } catch (error) {
-        console.error("Error updating GeoJSON data:", error);
-        throw error;
-    }
+  try {
+    const response = await axios({
+      method: "put",
+      url: `${DASHBOARD_API}/buildinggeojson`,
+      data: {
+        buildings: buildings,
+        pwd: process.env.API_PWD,
+      },
+    });
+    return response;
+  } catch (error) {
+    console.error("Error updating GeoJSON data:", error);
+    throw error;
+  }
 }
 
 async function main() {
-    // Build a map of wayId to building properties
-    const buildingMap = await createbuildingMap();
+  // Build a map of wayId to building properties
+  const buildingMap = await createbuildingMap();
 
-    // Get OSM data for all buildings
-    const wayIds = Array.from(buildingMap.keys()).join(',');
-    const geojson = await fetchGeoJSONData(wayIds);
+  // Get OSM data for all buildings
+  const wayIds = Array.from(buildingMap.keys()).join(",");
+  const geojson = await fetchGeoJSONData(wayIds);
 
-    // Prepare the GeoJSON data
-    const normalizedBuildingArray = normalizeData(buildingMap, geojson);
+  // Prepare the GeoJSON data
+  const normalizedBuildingArray = normalizeData(buildingMap, geojson);
 
-    // Update the database with the new GeoJSON data
-    if (!process.argv.includes("--no-upload")) {
-        const response = await updateGeoJSONData(normalizedBuildingArray);
-        console.log(response.data);
-      }
+  // Update the database with the new GeoJSON data
+  if (!process.argv.includes("--no-upload")) {
+    const response = await updateGeoJSONData(normalizedBuildingArray);
+    console.log(response.data);
+  }
 }
 
 // Execute the main function
-main()
+main();

--- a/refresh-osm/package-lock.json
+++ b/refresh-osm/package-lock.json
@@ -47,9 +47,9 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.8.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/refresh-osm/package-lock.json
+++ b/refresh-osm/package-lock.json
@@ -5,10 +5,10 @@
   "packages": {
     "": {
       "dependencies": {
+        "@xmldom/xmldom": "^0.9.8",
         "axios": "^1.8.4",
         "dotenv": "^16.5.0",
-        "osmtogeojson": "^3.0.0-beta.5",
-        "xmldom": "^0.6.0"
+        "osmtogeojson": "^3.0.0-beta.5"
       }
     },
     "node_modules/@mapbox/geojson-rewind": {
@@ -32,13 +32,12 @@
       "optional": true
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
-      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
-      "deprecated": "this version has critical issues, please update to the latest version",
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/asynckit": {
@@ -532,6 +531,16 @@
         "@types/geojson": "^7946.0"
       }
     },
+    "node_modules/osmtogeojson/node_modules/@xmldom/xmldom": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
+      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
+      "deprecated": "this version has critical issues, please update to the latest version",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/pbf": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
@@ -650,15 +659,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/xmldom": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
-      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     }
   }

--- a/refresh-osm/package-lock.json
+++ b/refresh-osm/package-lock.json
@@ -1,0 +1,665 @@
+{
+  "name": "refresh-osm",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "axios": "^1.8.4",
+        "dotenv": "^16.5.0",
+        "osmtogeojson": "^3.0.0-beta.5",
+        "xmldom": "^0.6.0"
+      }
+    },
+    "node_modules/@mapbox/geojson-rewind": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
+      "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
+      "license": "ISC",
+      "dependencies": {
+        "get-stream": "^6.0.1",
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "geojson-rewind": "geojson-rewind"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.3.tgz",
+      "integrity": "sha512-Lv2vySXypg4nfa51LY1nU8yDAGo/5YwF+EY/rUZgIbfvwVARcd67ttCM8SMsTeJy51YhHYavEq+FS6R0hW9PFQ==",
+      "deprecated": "this version has critical issues, please update to the latest version",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
+      "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/domhandler": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.2.1.tgz",
+      "integrity": "sha512-MFFBQFGkyTuNe3vL9WEw9JdlCwIoBYpOGESLeZAvc/jClYNsOl6P1KzevJbWg76GovdEycfR7/2/Ra7NnqtMKw==",
+      "dependencies": {
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.3.0.tgz",
+      "integrity": "sha512-1UdPmldjSGewOuWE40YYFZB1Q4im4LZoCMXGYeTeLz3R9hvxrDYJPRcPHXR4yBbubQebgGNCY2hwpJxmAiUMzQ==",
+      "dependencies": {
+        "domelementtype": "1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
+      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.2.tgz",
+      "integrity": "sha512-hGfm/slu0ZabnNt4oaRZ6uREyfCj6P4fT/n6A1rGV+Z0VdGXjfOhVUpkn6qVQONHGIFwmveGXyDs75+nr6FM8w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/geojson-numeric": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/geojson-numeric/-/geojson-numeric-0.2.1.tgz",
+      "integrity": "sha512-rvItMp3W7pe16o2EQTnRw54v6WHdiE4bYjUsdr3FZskFb6oPC7gjLe4zginP+Wd1B/HLl2acTukfn16Lmwn7lg==",
+      "license": "MIT",
+      "dependencies": {
+        "concat-stream": "2.0.0",
+        "optimist": "~0.3.5"
+      },
+      "bin": {
+        "geojson-numeric": "geojson-numeric"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.5.1.tgz",
+      "integrity": "sha512-9ouaQ6sjVJZS4NhPC65zNm2JCJotiH6BVm6iFvI90hRcsIEISMrgjqMUrPpU9G1VS4vTspH4dyaqSRf6JLQPbg==",
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "1",
+        "domhandler": "2.2",
+        "domutils": "1.3",
+        "readable-stream": "1.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsonparse": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-0.0.5.tgz",
+      "integrity": "sha512-fw7Q/8gFR8iSekUi9I+HqWIap6mywuoe7hQIg3buTVjuZgALKj4HAmm0X6f+TaL4c9NJbvyFQdaI2ppr5p6dnQ==",
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
+    "node_modules/JSONStream": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-0.8.0.tgz",
+      "integrity": "sha512-PiV28BpoUorz9kKFwRbD7+wg0t/k0ITHKn0DgCU44YZ/GaGAZRPt9q5PzoifC85gE55SEPIdMu0Labfxevj8cw==",
+      "dependencies": {
+        "jsonparse": "0.0.5",
+        "through": "~2.2.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/optimist": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+      "integrity": "sha512-TCx0dXQzVtSCg2OgY/bO9hjM9cV4XYx09TVK+s3+FhkjT6LovsLe+pPMzpWf+6yXK/hUizs2gUoTw3jHM0VaTQ==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/osm-polygon-features": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/osm-polygon-features/-/osm-polygon-features-0.9.2.tgz",
+      "integrity": "sha512-5zNEFCq+G6X2TDkqbKYLF1+GtWVCCLA8zX+FVhSogsiTRsGquyaGRy5cYNW4BE3ci0MKOLvNTkFNsjsCNtgz0A==",
+      "license": "CC0-1.0"
+    },
+    "node_modules/osmtogeojson": {
+      "version": "3.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/osmtogeojson/-/osmtogeojson-3.0.0-beta.5.tgz",
+      "integrity": "sha512-izvaUWnunrYvMB4LB0ZN15O1+g90c628yHS4SeSR3daVSBF9vdTHL7iVHfg0wEr1uEYjQ+lMJHCiYFusL5yKVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mapbox/geojson-rewind": "0.5.2",
+        "@xmldom/xmldom": "0.8.3",
+        "concat-stream": "2.0.0",
+        "geojson-numeric": "0.2.1",
+        "htmlparser2": "3.5.1",
+        "JSONStream": "0.8.0",
+        "optimist": "~0.3.5",
+        "osm-polygon-features": "^0.9.1",
+        "tiny-osmpbf": "^0.1.0"
+      },
+      "bin": {
+        "osmtogeojson": "osmtogeojson"
+      },
+      "engines": {
+        "node": ">=0.5"
+      },
+      "optionalDependencies": {
+        "@types/geojson": "^7946.0"
+      }
+    },
+    "node_modules/pbf": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
+      "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ieee754": "^1.1.12",
+        "resolve-protobuf-schema": "^2.1.0"
+      },
+      "bin": {
+        "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/protocol-buffers-schema": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/resolve-protobuf-schema": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
+      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "protocol-buffers-schema": "^3.3.1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/through": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+      "integrity": "sha512-JIR0m0ybkmTcR8URann+HbwKmodP+OE8UCbsifQDYMLD5J3em1Cdn3MYPpbEd5elGDwmP98T+WbqP/tvzA5Mjg==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-inflate": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
+      "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
+      "license": "MIT"
+    },
+    "node_modules/tiny-osmpbf": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-osmpbf/-/tiny-osmpbf-0.1.0.tgz",
+      "integrity": "sha512-Sl0xuDdM0+bnrYPhTAWnQ5eui8+2cpYCnsBxq0EFR1/IgmfB7+FiC23I8aa7tdP4AjaWvBUMK34kfXdY6C1LCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "pbf": "^3.0.4",
+        "tiny-inflate": "^1.0.2"
+      }
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xmldom": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.6.0.tgz",
+      "integrity": "sha512-iAcin401y58LckRZ0TkI4k0VSM1Qg0KGSc3i8rU+xrxe19A/BN1zHyVSJY7uoutVlaTSzYyk/v5AmkewAP7jtg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    }
+  }
+}

--- a/refresh-osm/package-lock.json
+++ b/refresh-osm/package-lock.json
@@ -1,14 +1,18 @@
 {
   "name": "refresh-osm",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "name": "refresh-osm",
+      "version": "1.0.0",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.8",
         "axios": "^1.8.4",
         "dotenv": "^16.5.0",
-        "osmtogeojson": "^3.0.0-beta.5"
+        "osmtogeojson": "^3.0.0-beta.5",
+        "prettier": "^3.0.1"
       }
     },
     "node_modules/@mapbox/geojson-rewind": {
@@ -552,6 +556,20 @@
       },
       "bin": {
         "pbf": "bin/pbf"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/protocol-buffers-schema": {

--- a/refresh-osm/package-lock.json
+++ b/refresh-osm/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "refresh-osm",
       "version": "1.0.0",
+      "license": "ISC",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.8",
         "axios": "^1.8.4",

--- a/refresh-osm/package.json
+++ b/refresh-osm/package.json
@@ -1,8 +1,26 @@
 {
+  "name": "refresh-osm",
+  "version": "1.0.0",
+  "description": "Refresh OSM data",
+  "main": "index.js",
+  "scripts": {
+    "format": "prettier --write ."
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/OSU-Sustainability-Office/automated-jobs.git"
+  },
+  "author": "Oregon State Sustainability Office",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/OSU-Sustainability-Office/automated-jobs/issues"
+  },
+  "homepage": "https://github.com/OSU-Sustainability-Office/automated-jobs#readme",
   "dependencies": {
     "@xmldom/xmldom": "^0.9.8",
     "axios": "^1.8.4",
     "dotenv": "^16.5.0",
-    "osmtogeojson": "^3.0.0-beta.5"
+    "osmtogeojson": "^3.0.0-beta.5",
+    "prettier": "^3.0.1"
   }
 }

--- a/refresh-osm/package.json
+++ b/refresh-osm/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "axios": "^1.8.4",
+    "dotenv": "^16.5.0",
+    "osmtogeojson": "^3.0.0-beta.5",
+    "xmldom": "^0.6.0"
+  }
+}

--- a/refresh-osm/package.json
+++ b/refresh-osm/package.json
@@ -1,8 +1,8 @@
 {
   "dependencies": {
+    "@xmldom/xmldom": "^0.9.8",
     "axios": "^1.8.4",
     "dotenv": "^16.5.0",
-    "osmtogeojson": "^3.0.0-beta.5",
-    "xmldom": "^0.6.0"
+    "osmtogeojson": "^3.0.0-beta.5"
   }
 }


### PR DESCRIPTION
# Summary #
The Energy Dashboard previously experienced slow startup times and occasional downtimes, largely due to its dependency on the third-party Overpass API for rendering building outlines. When a user accessed the dashboard, the system would:

1) Wait for all of building data to load from AWS Lambda (~3 ms)
2) Gather all of the building IDs then send a batched GET request to the Overpass API (which could range from milliseconds to over a minute, depending on network conditions)

To address this bottleneck, we’ve introduced an automated job that decouples the dashboard from the Overpass API by locally caching the required GeoJSON data. Since this building outline data is unlikely to change often, we’ll periodically refresh the local copy via a CRON job. In the rare case that the data changes frequently, we can revert back to live Overpass calls.

The tradeoff is that new buildings won’t appear on the map until this job is re-run, which introduces a minor manual step. However, I believe the benefits in speed and reliability will far outweigh this inconvenience.
