### PR TITLE
Fix two broken selectors and update axios

### DIFF
--- a/ennex-os/package-lock.json
+++ b/ennex-os/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "axios": "^1.7.7",
+        "axios": "^1.9.0",
         "dotenv": "^10.0.0",
         "prettier": "^3.0.1",
         "puppeteer": "^23.6.1"
@@ -132,9 +132,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -1436,9 +1436,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.1.tgz",
-      "integrity": "sha512-NN+fvwH/kV01dYUQ3PTOZns4LWtWhOFCAhQ/pHb88WQ1hNe5V/dvFwc4VJcDL11LT9xSX0QtsR8sWUuyOuOq7g==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
+      "integrity": "sha512-re4CqKTJaURpzbLHtIi6XpDv20/CnpXOtjRY5/CU32L8gU8ek9UIivcfvSWvmKEngmVbrUtPpdDwWDWL7DNHvg==",
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",

--- a/ennex-os/package.json
+++ b/ennex-os/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/OSU-Sustainability-Office/automated-jobs#readme",
   "dependencies": {
-    "axios": "^1.7.7",
+    "axios": "^1.9.0",
     "dotenv": "^10.0.0",
     "prettier": "^3.0.1",
     "puppeteer": "^23.6.1"

--- a/ennex-os/readEnnex.js
+++ b/ennex-os/readEnnex.js
@@ -28,14 +28,16 @@ const MONTHS = [
 ];
 
 // Selectors
-const ACCEPT_COOKIES = "#cmpwrapper >>> a.cmpboxbtn.cmpboxbtnyes.cmptxt_btn_yes";
+const ACCEPT_COOKIES =
+  "#cmpwrapper >>> a.cmpboxbtn.cmpboxbtnyes.cmptxt_btn_yes";
 const LOGIN_BUTTON = "button[name='login']";
 const USERNAME_SELECTOR = "#username";
 const PASSWORD_SELECTOR = "#password";
-const DETAILS_TAB_SELECTOR =
-  "body > sma-ennexos > div > mat-sidenav-container > mat-sidenav-content > div > div > sma-energy-and-power > sma-energy-and-power-container > div > div > div > div.ng-star-inserted > div.sma-main.ng-star-inserted > sma-advanced-chart > div > div > mat-accordion";
+const DETAILS_TAB_SELECTOR = "::-p-aria(Details)";
 const MONTHLY_TAB_SELECTOR = "[data-testid='MONTH']";
 const MONTH_DROPDOWN_SELECTOR = "#mat-select-value-0";
+const PV_SYSTEM_SELECTOR =
+  '::-p-xpath(//*[@id="header"]/sma-navbar/sma-navbar-container/nav/div[1]/sma-nav-node/div/sma-nav-element/button/div[2]/span)';
 
 //Non-constants
 let page = "";
@@ -376,10 +378,7 @@ async function getMeterData(meter) {
   await waitForTimeout(7500);
 
   // double-check that the meter name is correct
-  let PVSystem = await page.$eval(
-    '::-p-xpath(//*[@id="header"]/sma-navbar/sma-navbar-container/nav/div[1]/sma-nav-node/div/sma-nav-element/div/div[2]/span)',
-    (el) => el.innerText,
-  );
+  let PVSystem = await page.$eval(PV_SYSTEM_SELECTOR, (el) => el.innerText);
   console.log("Meter Name:", PVSystem);
 
   // iterate through the date range and get the daily data


### PR DESCRIPTION
Two selectors changed in the Sunny Portal, breaking the scraper for a week or so now. The `Details Tab Selector` is much more generic now, looking for the word "Details" instead of nested selectors, and should hopefully be less likely to break in the future. The `PVSystem` selector needed a slight change in the path (one `div` is now a `button` instead) and I made it a constant variable defined at the top of the page. I also updated `axios` as it had a critical vulnerability, it did not require any changes to the code after updating. This has already been uploaded to AWS in order to get the scraper back online, and missing data from when it was down has been uploaded.