### PR TITLE
Upload new meters to database before uploading the data

### DIFF
--- a/PacificPower/readPP.js
+++ b/PacificPower/readPP.js
@@ -1219,6 +1219,13 @@ class PacificPowerScraper {
         await this.getMeterData();
       }
 
+      // Add new meters found to database
+      if (!process.argv.includes("--no-upload")) {
+        await this.apiClient.addNewMetersToDatabase(
+          this.meterProcessor.ppMetersExcludeNotFound,
+        );
+      }
+
       // Log all data to be uploaded
       if (this.meterProcessor.ppArray.length > 0) {
         console.log("\nData to be uploaded: ");
@@ -1255,14 +1262,6 @@ class PacificPowerScraper {
       );
       // Print final results of arrays (meters with errors, meters excluded, etc)
       this.meterProcessor.printFinalResults();
-
-      // Add new meters found to database
-      if (!process.argv.includes("--no-upload")) {
-        await this.apiClient.addNewMetersToDatabase(
-          this.meterProcessor.ppMetersExcludeNotFound,
-        );
-      }
-
       if (
         process.argv.includes("--save-output") ||
         process.env.SAVE_OUTPUT === "true"


### PR DESCRIPTION
# Context # 
To align with proper database design, a foreign key constraint was added for pacific_power_meter_id. This means a meter must exist in the Pacific Power Meter Group before any corresponding data can be inserted into Pacific Power Data. As a result, meter uploads must occur before data uploads, otherwise the system will raise the error: `Cannot add or update a child row: a foreign key constraint fails`.